### PR TITLE
Update README and plan doc: Go MVP complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An agent-native CLI for Google Cloud's Data Cloud, built in Go.
 One binary for BigQuery, Spanner, AlloyDB, Cloud SQL, and Looker —
 with structured output, typed errors, and an MCP bridge for AI agents.
 
-> **Status:** Go MVP functional — 35 commands across 9 domains.
+> **Status:** Go MVP functional — 35 commands across 10 domains.
 > Benchmarked at **5x faster** than `bq` with token cost within 6%.
 > See [docs/benchmark_results_bigquery.md](docs/benchmark_results_bigquery.md)
 > for measured results.
@@ -159,7 +159,7 @@ Every command has a machine-readable contract accessible via
   "domain": "bigquery",
   "flags": [...],
   "exit_codes": {"0": "success", "2": "api_error", "3": "auth_error", "4": "not_found"},
-  "supports_dry_run": true,
+  "supports_dry_run": false,
   "is_mutation": false
 }
 ```

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ An agent-native CLI for Google Cloud's Data Cloud, built in Go.
 One binary for BigQuery, Spanner, AlloyDB, Cloud SQL, and Looker —
 with structured output, typed errors, and an MCP bridge for AI agents.
 
-> **Status:** Go rewrite in progress. The reference Rust implementation
-> lives at [`haiyuan-eng-google/bqx-cli`](https://github.com/haiyuan-eng-google/bqx-cli).
-> See [docs/go_mvp_plan.md](docs/go_mvp_plan.md) for the migration plan.
+> **Status:** Go MVP functional — 35 commands across 9 domains.
+> Benchmarked at **5x faster** than `bq` with token cost within 6%.
+> See [docs/benchmark_results_bigquery.md](docs/benchmark_results_bigquery.md)
+> for measured results.
 
 ## Why dcx
 
@@ -15,54 +16,54 @@ with structured output, typed errors, and an MCP bridge for AI agents.
 - **Machine-safe output.** Structured JSON on stdout, typed errors on
   stderr, deterministic exit codes. Built for agents, scripts, and CI.
 - **Token-efficient.** `--format=json-minified` delivers the same schema
-  with 27% fewer tokens than pretty JSON — measured, not projected.
+  with 31% fewer tokens than pretty JSON — measured, not projected.
 - **Self-describing.** `meta commands` and `meta describe` expose the
   full command contract as machine-readable JSON. MCP bridge and agent
   skills are generated from the same contract model.
+- **5x faster than `bq`.** A 6-step agent workflow completes in 3.2
+  seconds vs 15.7 seconds with `bq`.
 
 ## Quick Start
 
-> **Not yet functional.** The Go implementation is in progress.
-> These commands show the target interface — see
-> [docs/go_mvp_plan.md](docs/go_mvp_plan.md) for current status.
-
 ```bash
-# Build from source (stub only — exits with "not yet implemented")
+# Build from source
 go build -o dcx ./cmd/dcx
 
-# Target interface (Phase 1–5):
-dcx auth check                # verify credentials
+# Verify auth
+dcx auth check
+
+# Explore BigQuery
 dcx datasets list --project-id=myproject
+dcx tables list --project-id=myproject --dataset-id=mydataset
 dcx jobs query --project-id=myproject --query="SELECT 1"
-dcx meta describe jobs query  # inspect any command's contract
-dcx mcp serve                 # start MCP server for agents
+
+# Inspect any command's contract
+dcx meta describe jobs query
+
+# Natural-language query via CA
+dcx ca ask "top errors yesterday" --profile my-spanner-profile
+
+# Start MCP server for agents
+dcx mcp serve
 ```
 
-For a working CLI today, use the Rust reference implementation:
-[`haiyuan-eng-google/bqx-cli`](https://github.com/haiyuan-eng-google/bqx-cli).
-
-## MVP Scope
-
-This Go implementation targets the smallest `dcx` that preserves the
-current product wedge. See [docs/go_mvp_plan.md](docs/go_mvp_plan.md)
-for the full plan.
-
-### P0: What ships
+## Commands (35 total)
 
 | Surface | Commands |
 |---|---|
-| **Core runtime** | `--format json\|json-minified\|table\|text`, structured errors, semantic exit codes, 5-tier auth |
-| **BigQuery** | `datasets list/get`, `tables list/get`, `jobs query`, `jobs query --dry-run` |
-| **Spanner** | `instances list`, `databases list/get-ddl`, `schema describe` |
-| **AlloyDB** | `clusters list`, `instances list`, `databases list`, `schema describe` |
-| **Cloud SQL** | `instances list`, `databases list`, `schema describe` |
-| **Looker** | `instances list`, `explores list`, `dashboards get` |
+| **BigQuery** | `datasets list/get`, `tables list/get`, `jobs query` (with `--dry-run`) |
+| **Spanner** | `instances list/get`, `databases list/get/get-ddl`, `schema describe` |
+| **AlloyDB** | `clusters list/get`, `instances list/get`, `databases list`, `schema describe` |
+| **Cloud SQL** | `instances list/get`, `databases list/get`, `schema describe` |
+| **Looker** | `instances list/get`, `explores list`, `dashboards get` |
 | **CA** | `ca ask --profile ...` (natural-language queries across all sources) |
 | **Auth** | `auth status`, `auth check` |
 | **Profiles** | `profiles list`, `profiles validate`, `profiles test` |
 | **Introspection** | `meta commands`, `meta describe` |
 | **MCP** | `mcp serve` (JSON-RPC 2.0 / stdio, read-only, default `json-minified`) |
 | **Skills** | `dcx-bigquery`, `dcx-databases`, `dcx-looker`, `dcx-ca` (checked-in) |
+
+Run `dcx meta commands` for the full machine-readable list.
 
 ### Deferred to P1
 
@@ -71,11 +72,9 @@ for the full plan.
 - `generate-skills`, Gemini manifest, shell completions
 - Model Armor sanitization
 
-## Output Format (target contract)
+## Output Format
 
-All commands will default to structured JSON. `--format` controls output.
-These examples show the target output shape from the
-[Rust reference implementation](https://github.com/haiyuan-eng-google/bqx-cli):
+All commands default to structured JSON. `--format` controls output:
 
 ```bash
 dcx datasets list --project-id=myproject --format=json-minified
@@ -89,7 +88,7 @@ dcx datasets list --project-id=myproject --format=table
 | Format | Use case |
 |---|---|
 | `json` | Human-readable, debugging |
-| `json-minified` | Agent pipelines, CI (27% fewer tokens) |
+| `json-minified` | Agent pipelines, CI (31% fewer tokens) |
 | `table` | Visual scanning |
 | `text` | Command-specific plain text |
 
@@ -106,24 +105,47 @@ Five methods in priority order:
 |----------|--------|----------|
 | 1 | `DCX_TOKEN` env var / `--token` | Pre-obtained access token |
 | 2 | `DCX_CREDENTIALS_FILE` / `--credentials-file` | Service account JSON |
-| 3 | `dcx auth login` | Interactive OAuth |
+| 3 | `dcx auth login` | Interactive OAuth (P1) |
 | 4 | `GOOGLE_APPLICATION_CREDENTIALS` | Standard ADC |
 | 5 | `gcloud auth application-default` | Implicit gcloud credentials |
+
+## Benchmarks
+
+Measured on the BigQuery 12-task parity suite (Go `dcx` vs `bq`):
+
+| Metric | dcx | dcx (minified) | bq |
+|--------|-----|----------------|-----|
+| **Avg warm p50** | 518 ms | 503 ms | 2,526 ms |
+| **Speedup** | **4.9x** | **5.0x** | baseline |
+| **6-step workflow** | **3.2s** | **3.2s** | 15.7s |
+| **Workflow tokens** | ~3,241 | **~2,239** | ~2,115 |
+
+See [docs/benchmark_results_bigquery.md](docs/benchmark_results_bigquery.md)
+for the full breakdown including per-task results, token efficiency analysis,
+and Go vs Rust comparison.
+
+```bash
+# Reproduce
+go build -o dcx ./cmd/dcx
+benchmarks/scripts/seed_bigquery.sh YOUR_PROJECT_ID
+benchmarks/scripts/run_benchmarks.sh --tasks bigquery_overlap --trials 3 --cold-trials 1
+python3 benchmarks/scripts/score_results.py benchmarks/results/raw/<run-id>
+```
 
 ## Architecture
 
 ### Dynamic Command Generation
 
-dcx generates commands from bundled Google Cloud Discovery Documents at
-build time (embedded via `go:embed`). No runtime fetch, no network dependency.
+dcx generates commands from bundled Google Cloud Discovery Documents
+(embedded via `go:embed`). No runtime fetch, no network dependency.
 
 | Service | Namespace | Discovery Doc | Commands |
 |---------|-----------|---------------|----------|
-| BigQuery | _(top-level)_ | `bigquery/v2` | datasets, tables, routines, models |
+| BigQuery | _(top-level)_ | `bigquery/v2` | datasets, tables |
 | Spanner | `spanner` | `spanner/v1` | instances, databases, getDdl |
 | AlloyDB | `alloydb` | `alloydb/v1` | clusters, instances |
 | Cloud SQL | `cloudsql` | `sqladmin/v1` | instances, databases |
-| Looker | `looker` | `looker/v1` | instances, backups |
+| Looker | `looker` | `looker/v1` | instances |
 
 ### Contract System
 
@@ -169,25 +191,6 @@ database_id: my-database
 Supported source types: `bigquery`, `looker`, `looker_studio`, `alloy_db`,
 `spanner`, `cloud_sql`.
 
-## Benchmarks
-
-Benchmark suite carried over from the Rust implementation. Compares dcx
-against `bq` and `gcloud` on real workflows.
-
-| Track | Tasks | Measured baseline (Rust) |
-|-------|-------|------------------------|
-| BigQuery parity | 12 tasks x 3 CLIs | 4.8x faster than `bq`, 27% fewer tokens |
-| Spanner parity | 11 tasks x 2 CLIs | 1.3-3.9x faster on error-handling tasks |
-| dcx differentiated | 8 tasks | 7/8 pass, avg 141 ms |
-
-```bash
-benchmarks/scripts/run_benchmarks.sh --tasks bigquery_overlap --trials 3 --cold-trials 1
-python3 benchmarks/scripts/score_results.py benchmarks/results/raw/<run-id>
-```
-
-The Go implementation must meet or beat these numbers before MVP release.
-See [docs/go_mvp_plan.md](docs/go_mvp_plan.md) for success criteria.
-
 ## Project Structure
 
 ```
@@ -197,35 +200,45 @@ internal/
   contracts/                    # CommandContract, meta commands/describe
   output/                       # render(format, value), table formatting
   errors/                       # ErrorEnvelope, ErrorCode, exit codes
-  auth/                         # 5-tier resolver, OAuth login, keyring
+  auth/                         # 5-tier resolver
   discovery/                    # Discovery Document parser, command generation
   bigquery/                     # jobs query (static), BQ client
-  ca/                           # CA client (Chat + QueryData), profiles
+  ca/                           # CA client (Chat + QueryData)
   datacloud/                    # database helpers (schema describe)
   looker/                       # Looker Admin SDK client
   mcp/                          # MCP server (JSON-RPC 2.0 / stdio)
   profiles/                     # profile commands
-  skills/                       # skill templates
+  eval/                         # deterministic CLI eval suite (CI gate)
 assets/                         # embedded Discovery JSONs (go:embed)
 skills/                         # checked-in SKILL.md files
 benchmarks/                     # task specs, runner, scorer
+.github/workflows/ci.yml       # CI: build + test + eval gate
 docs/
 ```
+
+## CI
+
+Every push and PR runs:
+
+1. `go build` — binary compiles
+2. `go test ./...` — unit tests across all packages
+3. Eval suite — 11 deterministic categories validating command discovery,
+   contract completeness, error handling, exit codes, help output, format
+   support, auth preflight, skill alignment, and JSON contract stability
 
 ## Migration from Rust
 
 This repo is a Go rewrite of
 [`haiyuan-eng-google/bqx-cli`](https://github.com/haiyuan-eng-google/bqx-cli).
-The Rust implementation remains the source of truth during migration.
 
-Migration phases:
+All 6 migration phases are complete:
 
-1. **Phase 1:** Core runtime (CLI tree, output, errors, auth, `meta`)
-2. **Phase 2:** BigQuery P0 (Discovery pipeline, datasets, tables, query)
-3. **Phase 3:** Data Cloud Discovery commands (Spanner, AlloyDB, Cloud SQL, Looker)
-4. **Phase 4:** CA + QueryData helpers + profiles + Looker SDK
-5. **Phase 5:** MCP bridge + checked-in skills
-6. **Phase 6:** Benchmark hardening + release
+1. **Phase 1:** Core runtime (CLI tree, output, errors, auth, `meta`) — merged
+2. **Phase 2:** BigQuery P0 (Discovery pipeline, datasets, tables, query) — merged
+3. **Phase 3:** Data Cloud Discovery commands (Spanner, AlloyDB, Cloud SQL, Looker) — merged
+4. **Phase 4:** CA + QueryData helpers + profiles + Looker SDK — merged
+5. **Phase 5:** MCP bridge + checked-in skills — merged
+6. **Phase 6:** Benchmark hardening + eval suite + CI gate — merged
 
 See [docs/go_mvp_plan.md](docs/go_mvp_plan.md) for the full plan with
 success criteria, implementation types, and dependency analysis.

--- a/docs/go_mvp_plan.md
+++ b/docs/go_mvp_plan.md
@@ -717,7 +717,7 @@ The right message is:
 ## Implementation status
 
 All 6 phases are complete. The Go MVP is functional with 35 commands
-across 9 domains, benchmarked at 5x faster than `bq`.
+across 10 domains, benchmarked at 5x faster than `bq`.
 
 | Phase | Status | PR |
 |-------|--------|-----|

--- a/docs/go_mvp_plan.md
+++ b/docs/go_mvp_plan.md
@@ -714,21 +714,26 @@ The right message is:
 
 > "Go MVP of dcx: BigQuery + Data Cloud source commands + CA ask + meta/MCP + CLI benchmark suite."
 
-## Immediate next steps
+## Implementation status
 
-1. Create `haiyuan-eng-google/dcx-cli` with `go mod init`
-2. Copy benchmark, skills, docs, and Discovery assets from `bqx-cli`
-3. Export Rust command contracts for all P0 commands into
-   `testdata/rust-snapshots/`
-4. Implement Go Phase 1 (core runtime + contract)
-5. Do not start Data Cloud services until the BigQuery benchmark core and
-   contract system are working end to end in the Go repo
+All 6 phases are complete. The Go MVP is functional with 35 commands
+across 9 domains, benchmarked at 5x faster than `bq`.
+
+| Phase | Status | PR |
+|-------|--------|-----|
+| Phase 1: Core runtime | Merged | #2 |
+| Phase 2: BigQuery P0 | Merged | #2 |
+| Phase 3: Data Cloud Discovery | Merged | #2 |
+| Phase 4: CA + QueryData + Looker | Merged | #3 |
+| Phase 5: MCP + skills | Merged | #2 |
+| Phase 6: Eval suite + CI | Merged | #4 |
+| Benchmark run + docs | Merged | #5 |
 
 ## Bottom line
 
-The Go MVP should not be "all of current `bqx-cli` in another language."
+The Go MVP is not "all of current `bqx-cli` in another language."
 
-It should be:
+It is:
 
 - BigQuery core (Discovery + static query)
 - Data Cloud source core (Discovery + QueryData helpers + Looker SDK)


### PR DESCRIPTION
## Summary

- **README**: Removes all "not yet functional" / "stub only" / "target interface" language. The Go CLI is functional with 35 commands, benchmarked results, and a CI gate. Updated Quick Start, command table, benchmark numbers, architecture section, and migration status.
- **Plan doc**: Replaces "Immediate next steps" with an implementation status table showing all 6 phases merged with PR numbers.

Key changes:
- Status line: "Go MVP functional — 35 commands across 9 domains"
- Benchmark: "5x faster than bq, 3.2s workflow vs 15.7s"
- Token efficiency: updated from 27% to 31% (Go measured)
- All 6 phases marked complete
- Added CI section describing the eval gate
- Removed references to "Rust reference implementation" as the working CLI

## Test plan

- [ ] README renders correctly on GitHub
- [ ] No broken links
- [ ] `go build` and `go test ./...` unaffected (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)