### PR TITLE
Implement CA agent management: create-agent, list-agents, add-verified-query

### DIFF
--- a/internal/ca/client.go
+++ b/internal/ca/client.go
@@ -79,8 +79,9 @@ func (c *Client) askChat(ctx context.Context, token string, profile *profiles.Pr
 	}
 
 	// Agent context (BigQuery with named agent).
+	// Agent resources live in locations/global regardless of chat endpoint location.
 	if agent != "" {
-		agentResource := fmt.Sprintf("projects/%s/locations/%s/dataAgents/%s", projectID, location, agent)
+		agentResource := fmt.Sprintf("projects/%s/locations/global/dataAgents/%s", projectID, agent)
 		body["data_agent_context"] = map[string]interface{}{
 			"data_agent": agentResource,
 		}
@@ -291,17 +292,15 @@ func (c *Client) AskQueryDataRaw(ctx context.Context, token string, profile *pro
 	return raw, nil
 }
 
-// CreateAgent creates a new BigQuery data agent via the Data Agents v1alpha API.
-// The API returns a long-running Operation; we surface the operation name.
-// Docs: https://docs.cloud.google.com/gemini/data-agents/reference/rest/v1alpha/projects.locations.dataAgents/create
 // CreateAgent creates a data agent synchronously via :createSync.
 // Uses publishedContext (not stagingContext) matching the Rust implementation.
+// Agent management uses locations/global (not regional like chat/queryData).
 func (c *Client) CreateAgent(ctx context.Context, token, projectID, location string, opts CreateAgentOpts) (*CreateAgentResult, error) {
 	if projectID == "" {
 		return nil, fmt.Errorf("project ID is required")
 	}
 	if location == "" {
-		location = "us"
+		location = "global"
 	}
 
 	tableRefs := buildBQTableRefs(strings.Join(opts.Tables, ","))
@@ -374,13 +373,13 @@ func (c *Client) CreateAgent(ctx context.Context, token, projectID, location str
 }
 
 // ListAgents lists all data agents in the given project, handling pagination.
-// Docs: https://docs.cloud.google.com/gemini/data-agents/reference/rest/v1alpha/projects.locations.dataAgents/list
+// Agent management uses locations/global (not regional like chat/queryData).
 func (c *Client) ListAgents(ctx context.Context, token, projectID, location string) (*AgentsListResult, error) {
 	if projectID == "" {
 		return nil, fmt.Errorf("project ID is required")
 	}
 	if location == "" {
-		location = "us"
+		location = "global"
 	}
 
 	baseURL := fmt.Sprintf(dataAgentsURLFmt, projectID, location)
@@ -459,18 +458,15 @@ func extractErrorMessage(body []byte, statusCode int) string {
 	return fmt.Sprintf("API returned HTTP %d", statusCode)
 }
 
-// AddVerifiedQuery adds example queries to an existing data agent via PATCH.
-// There is no standalone addVerifiedQuery method in the API; verified queries
-// (exampleQueries) are fields on the DataAgent resource updated via patch.
-// Docs: https://docs.cloud.google.com/gemini/data-agents/reference/rest/v1alpha/projects.locations.dataAgents
 // AddVerifiedQuery appends example queries to an existing agent via GET + :updateSync.
 // Uses publishedContext (matching Rust implementation).
+// Agent management uses locations/global (not regional like chat/queryData).
 func (c *Client) AddVerifiedQuery(ctx context.Context, token, projectID, location string, opts PatchAgentOpts) (*AddVerifiedQueryResult, error) {
 	if projectID == "" {
 		return nil, fmt.Errorf("project ID is required")
 	}
 	if location == "" {
-		location = "us"
+		location = "global"
 	}
 
 	// 1. GET the existing agent to read current exampleQueries.

--- a/internal/ca/client.go
+++ b/internal/ca/client.go
@@ -17,6 +17,11 @@ const (
 
 	// CA QueryData API endpoint (Spanner, AlloyDB, Cloud SQL).
 	queryDataAPIURL = "https://datacatalog.googleapis.com/v1/projects/%s/locations/%s:queryData"
+
+	// CA DataAgent management endpoints.
+	createAgentURL       = "https://datacatalog.googleapis.com/v1/projects/%s/locations/%s/dataAgents"
+	listAgentsURL        = "https://datacatalog.googleapis.com/v1/projects/%s/locations/%s/dataAgents"
+	addVerifiedQueryURL  = "https://datacatalog.googleapis.com/v1/projects/%s/locations/%s/dataAgents/%s:addVerifiedQuery"
 )
 
 // Client provides access to the Conversational Analytics APIs.
@@ -250,6 +255,177 @@ func (c *Client) AskQueryDataRaw(ctx context.Context, token string, profile *pro
 		return nil, fmt.Errorf("parsing querydata response: %w", err)
 	}
 	return raw, nil
+}
+
+// CreateAgent creates a new BigQuery data agent.
+func (c *Client) CreateAgent(ctx context.Context, token, projectID, location string, req CreateAgentRequest) (*CreateAgentResult, error) {
+	if projectID == "" {
+		return nil, fmt.Errorf("project ID is required")
+	}
+	if location == "" {
+		location = "us"
+	}
+
+	url := fmt.Sprintf(createAgentURL, projectID, location)
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling create-agent request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("create-agent API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, readAPIError(resp)
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading create-agent response: %w", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(respBody, &raw); err != nil {
+		return nil, fmt.Errorf("parsing create-agent response: %w", err)
+	}
+
+	name := ""
+	if n, ok := raw["name"].(string); ok {
+		name = n
+	}
+
+	return &CreateAgentResult{
+		Name:   name,
+		Status: "created",
+	}, nil
+}
+
+// ListAgents lists data agents in the given project.
+func (c *Client) ListAgents(ctx context.Context, token, projectID, location string) (*AgentsListResult, error) {
+	if projectID == "" {
+		return nil, fmt.Errorf("project ID is required")
+	}
+	if location == "" {
+		location = "us"
+	}
+
+	url := fmt.Sprintf(listAgentsURL, projectID, location)
+
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := c.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("list-agents API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, readAPIError(resp)
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading list-agents response: %w", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(respBody, &raw); err != nil {
+		return nil, fmt.Errorf("parsing list-agents response: %w", err)
+	}
+
+	var agents []AgentSummary
+	if items, ok := raw["dataAgents"].([]interface{}); ok {
+		for _, item := range items {
+			if m, ok := item.(map[string]interface{}); ok {
+				agent := AgentSummary{}
+				if n, ok := m["name"].(string); ok {
+					agent.Name = n
+				}
+				if t, ok := m["createTime"].(string); ok {
+					agent.CreateTime = t
+				}
+				if tables, ok := m["tables"].([]interface{}); ok {
+					for _, t := range tables {
+						if s, ok := t.(string); ok {
+							agent.Tables = append(agent.Tables, s)
+						}
+					}
+				}
+				if vqs, ok := m["verifiedQueries"].([]interface{}); ok {
+					agent.VerifiedQueries = len(vqs)
+				}
+				agents = append(agents, agent)
+			}
+		}
+	}
+
+	if agents == nil {
+		agents = []AgentSummary{}
+	}
+
+	return &AgentsListResult{
+		Items:  agents,
+		Source: "BigQuery",
+	}, nil
+}
+
+// AddVerifiedQuery adds a verified query to an existing data agent.
+func (c *Client) AddVerifiedQuery(ctx context.Context, token, projectID, location string, req AddVerifiedQueryRequest) (*AddVerifiedQueryResult, error) {
+	if projectID == "" {
+		return nil, fmt.Errorf("project ID is required")
+	}
+	if location == "" {
+		location = "us"
+	}
+
+	url := fmt.Sprintf(addVerifiedQueryURL, projectID, location, req.Agent)
+
+	body, err := json.Marshal(map[string]interface{}{
+		"question": req.Question,
+		"query":    req.Query,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling add-verified-query request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("add-verified-query API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, readAPIError(resp)
+	}
+
+	return &AddVerifiedQueryResult{
+		Agent:    req.Agent,
+		Question: req.Question,
+		Status:   "added",
+	}, nil
 }
 
 func readAPIError(resp *http.Response) error {

--- a/internal/ca/client.go
+++ b/internal/ca/client.go
@@ -338,7 +338,7 @@ func (c *Client) CreateAgent(ctx context.Context, token, projectID, location str
 	}, nil
 }
 
-// ListAgents lists data agents in the given project via the Data Agents v1alpha API.
+// ListAgents lists all data agents in the given project, handling pagination.
 // Docs: https://docs.cloud.google.com/gemini/data-agents/reference/rest/v1alpha/projects.locations.dataAgents/list
 func (c *Client) ListAgents(ctx context.Context, token, projectID, location string) (*AgentsListResult, error) {
 	if projectID == "" {
@@ -348,52 +348,80 @@ func (c *Client) ListAgents(ctx context.Context, token, projectID, location stri
 		location = "us"
 	}
 
-	apiURL := fmt.Sprintf(dataAgentsBaseURL, projectID, location)
+	baseURL := fmt.Sprintf(dataAgentsBaseURL, projectID, location)
+	var allAgents []AgentSummary
+	pageToken := ""
 
-	httpReq, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	httpReq.Header.Set("Authorization", "Bearer "+token)
-	httpReq.Header.Set("Accept", "application/json")
+	for {
+		apiURL := baseURL
+		if pageToken != "" {
+			apiURL += "?pageToken=" + pageToken
+		}
 
-	resp, err := c.HTTPClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("list-agents API request failed: %w", err)
-	}
-	defer resp.Body.Close()
+		httpReq, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+		httpReq.Header.Set("Authorization", "Bearer "+token)
+		httpReq.Header.Set("Accept", "application/json")
 
-	if resp.StatusCode >= 400 {
-		return nil, readAPIError(resp)
-	}
+		resp, err := c.HTTPClient.Do(httpReq)
+		if err != nil {
+			return nil, fmt.Errorf("list-agents API request failed: %w", err)
+		}
 
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading list-agents response: %w", err)
-	}
+		respBody, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
 
-	var raw map[string]interface{}
-	if err := json.Unmarshal(respBody, &raw); err != nil {
-		return nil, fmt.Errorf("parsing list-agents response: %w", err)
-	}
+		if resp.StatusCode >= 400 {
+			return nil, fmt.Errorf("list-agents: %s", extractErrorMessage(respBody, resp.StatusCode))
+		}
 
-	var agents []AgentSummary
-	if items, ok := raw["dataAgents"].([]interface{}); ok {
-		for _, item := range items {
-			if m, ok := item.(map[string]interface{}); ok {
-				agents = append(agents, parseAgentSummary(m))
+		if err != nil {
+			return nil, fmt.Errorf("reading list-agents response: %w", err)
+		}
+
+		var raw map[string]interface{}
+		if err := json.Unmarshal(respBody, &raw); err != nil {
+			return nil, fmt.Errorf("parsing list-agents response: %w", err)
+		}
+
+		if items, ok := raw["dataAgents"].([]interface{}); ok {
+			for _, item := range items {
+				if m, ok := item.(map[string]interface{}); ok {
+					allAgents = append(allAgents, parseAgentSummary(m))
+				}
 			}
 		}
+
+		// Check for next page.
+		npt, _ := raw["nextPageToken"].(string)
+		if npt == "" {
+			break
+		}
+		pageToken = npt
 	}
 
-	if agents == nil {
-		agents = []AgentSummary{}
+	if allAgents == nil {
+		allAgents = []AgentSummary{}
 	}
 
 	return &AgentsListResult{
-		Items:  agents,
+		Items:  allAgents,
 		Source: "BigQuery",
 	}, nil
+}
+
+func extractErrorMessage(body []byte, statusCode int) string {
+	var apiErr struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(body, &apiErr) == nil && apiErr.Error.Message != "" {
+		return apiErr.Error.Message
+	}
+	return fmt.Sprintf("API returned HTTP %d", statusCode)
 }
 
 // AddVerifiedQuery adds example queries to an existing data agent via PATCH.
@@ -477,10 +505,30 @@ func (c *Client) AddVerifiedQuery(ctx context.Context, token, projectID, locatio
 		return nil, readAPIError(patchResp)
 	}
 
+	// PATCH returns a long-running Operation, not the updated agent.
+	patchRespBody, err := io.ReadAll(patchResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading patch response: %w", err)
+	}
+
+	var patchOp map[string]interface{}
+	if err := json.Unmarshal(patchRespBody, &patchOp); err != nil {
+		return nil, fmt.Errorf("parsing patch response: %w", err)
+	}
+
+	opName, _ := patchOp["name"].(string)
+	done, _ := patchOp["done"].(bool)
+
+	status := "operation_started"
+	if done {
+		status = "completed"
+	}
+
 	return &AddVerifiedQueryResult{
-		Agent:        opts.AgentName,
-		QueriesAdded: len(opts.ExampleQueries),
-		Status:       "added",
+		Agent:         opts.AgentName,
+		QueriesAdded:  len(opts.ExampleQueries),
+		OperationName: opName,
+		Status:        status,
 	}, nil
 }
 

--- a/internal/ca/client.go
+++ b/internal/ca/client.go
@@ -13,15 +13,20 @@ import (
 )
 
 const (
-	// All CA endpoints are on the geminidataanalytics v1alpha API.
-	// Docs: https://docs.cloud.google.com/gemini/data-agents/reference/rest/v1alpha
+	// CA base URL — v1beta matches the working Rust implementation.
+	caBaseURL = "https://geminidataanalytics.googleapis.com/v1beta"
 
-	// queryData: NL-to-SQL for all source types (BigQuery, Spanner, AlloyDB, Cloud SQL, Looker).
-	queryDataURL = "https://geminidataanalytics.googleapis.com/v1alpha/projects/%s/locations/%s:queryData"
+	// :chat endpoint for BigQuery/Looker/Studio (streaming messages).
+	chatURLFmt = caBaseURL + "/projects/%s/locations/%s:chat"
 
-	// Data Agents management endpoints.
-	dataAgentsBaseURL = "https://geminidataanalytics.googleapis.com/v1alpha/projects/%s/locations/%s/dataAgents"
-	dataAgentURL      = "https://geminidataanalytics.googleapis.com/v1alpha/%s" // takes full resource name
+	// :queryData endpoint for database sources (Spanner, AlloyDB, Cloud SQL).
+	queryDataURLFmt = caBaseURL + "/projects/%s/locations/%s:queryData"
+
+	// Agent management endpoints (sync variants return result directly).
+	dataAgentsURLFmt    = caBaseURL + "/projects/%s/locations/%s/dataAgents"
+	dataAgentURLFmt     = caBaseURL + "/%s" // takes full resource name
+	createAgentSyncFmt  = caBaseURL + "/projects/%s/locations/%s/dataAgents:createSync?dataAgentId=%s"
+	updateAgentSyncFmt  = caBaseURL + "/%s:updateSync?updateMask=%s"
 )
 
 // Client provides access to the Conversational Analytics APIs.
@@ -37,11 +42,20 @@ func NewClient(httpClient *http.Client) *Client {
 	return &Client{HTTPClient: httpClient}
 }
 
-// Ask sends a question to the queryData endpoint, routing to the correct
-// datasource type based on the profile. All source types use the same
-// geminidataanalytics.googleapis.com/v1alpha queryData endpoint.
-// Docs: https://docs.cloud.google.com/gemini/data-agents/reference/rest/v1alpha/projects.locations/queryData
+// Ask routes a question to the appropriate CA endpoint based on source type.
+// BigQuery/Looker/Studio use :chat (streaming messages).
+// Spanner/AlloyDB/CloudSQL use :queryData (NL-to-SQL).
+// This matches the working Rust implementation.
 func (c *Client) Ask(ctx context.Context, token string, profile *profiles.Profile, question, agent, tables string) (*AskResult, error) {
+	if profile != nil && profile.IsQueryDataSource() {
+		return c.askQueryData(ctx, token, profile, question)
+	}
+	return c.askChat(ctx, token, profile, question, agent, tables)
+}
+
+// askChat sends a question to the :chat endpoint (BigQuery/Looker/Studio).
+// Uses messages + userMessage + inlineContext structure.
+func (c *Client) askChat(ctx context.Context, token string, profile *profiles.Profile, question, agent, tables string) (*AskResult, error) {
 	projectID := ""
 	location := "us"
 	if profile != nil {
@@ -54,11 +68,110 @@ func (c *Client) Ask(ctx context.Context, token string, profile *profiles.Profil
 		return nil, fmt.Errorf("project ID is required for ca ask")
 	}
 
-	// Build the queryData request with the documented schema.
-	reqBody := map[string]interface{}{
+	userMessage := map[string]interface{}{
+		"userMessage": map[string]interface{}{
+			"text": question,
+		},
+	}
+
+	body := map[string]interface{}{
+		"messages": []interface{}{userMessage},
+	}
+
+	// Agent context (BigQuery with named agent).
+	if agent != "" {
+		agentResource := fmt.Sprintf("projects/%s/locations/%s/dataAgents/%s", projectID, location, agent)
+		body["data_agent_context"] = map[string]interface{}{
+			"data_agent": agentResource,
+		}
+	}
+
+	// Inline tables (BigQuery without agent).
+	if agent == "" && tables != "" {
+		tableRefs := buildBQTableRefs(tables)
+		body["inlineContext"] = map[string]interface{}{
+			"datasource_references": map[string]interface{}{
+				"bq": map[string]interface{}{
+					"tableReferences": tableRefs,
+				},
+			},
+		}
+	}
+
+	// Looker profile: pass explore references.
+	if profile != nil && profile.SourceType == profiles.Looker {
+		exploreRefs := buildLookerExploreRefs(profile)
+		body["inlineContext"] = map[string]interface{}{
+			"datasourceReferences": map[string]interface{}{
+				"looker": map[string]interface{}{
+					"exploreReferences": exploreRefs,
+				},
+			},
+		}
+	}
+
+	bodyJSON, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling chat request: %w", err)
+	}
+
+	apiURL := fmt.Sprintf(chatURLFmt, projectID, location)
+	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(bodyJSON))
+	if err != nil {
+		return nil, fmt.Errorf("creating chat request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-server-timeout", "300")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("chat API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, readAPIError(resp)
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading chat response: %w", err)
+	}
+
+	// Parse streaming response (JSON array of messages).
+	result, err := parseChatResponse(respBody, question, agent)
+	if err != nil {
+		return nil, err
+	}
+
+	if profile != nil {
+		result.Source = sourceName(profile.SourceType)
+	} else {
+		result.Source = "BigQuery"
+	}
+
+	return result, nil
+}
+
+// askQueryData sends a question to the :queryData endpoint (Spanner/AlloyDB/CloudSQL).
+// Uses prompt + context.datasourceReferences structure.
+func (c *Client) askQueryData(ctx context.Context, token string, profile *profiles.Profile, question string) (*AskResult, error) {
+	if profile.Project == "" {
+		return nil, fmt.Errorf("project is required in profile")
+	}
+
+	location := profile.Location
+	if location == "" {
+		location = "us"
+	}
+
+	datasourceRef := buildQueryDataDatasourceRef(profile)
+
+	body := map[string]interface{}{
 		"prompt": question,
 		"context": map[string]interface{}{
-			"datasourceReferences": buildDatasourceReferences(profile, tables),
+			"datasourceReferences": datasourceRef,
 		},
 		"generationOptions": map[string]interface{}{
 			"generateQueryResult":           true,
@@ -67,18 +180,19 @@ func (c *Client) Ask(ctx context.Context, token string, profile *profiles.Profil
 		},
 	}
 
-	body, err := json.Marshal(reqBody)
+	bodyJSON, err := json.Marshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling queryData request: %w", err)
 	}
 
-	apiURL := fmt.Sprintf(queryDataURL, projectID, location)
-	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(body))
+	apiURL := fmt.Sprintf(queryDataURLFmt, profile.Project, location)
+	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(bodyJSON))
 	if err != nil {
 		return nil, fmt.Errorf("creating queryData request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-server-timeout", "300")
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
@@ -95,7 +209,6 @@ func (c *Client) Ask(ctx context.Context, token string, profile *profiles.Profil
 		return nil, fmt.Errorf("reading queryData response: %w", err)
 	}
 
-	// Parse the documented QueryDataResponse.
 	var raw map[string]interface{}
 	if err := json.Unmarshal(respBody, &raw); err != nil {
 		return nil, fmt.Errorf("parsing queryData response: %w", err)
@@ -117,9 +230,6 @@ func (c *Client) Ask(ctx context.Context, token string, profile *profiles.Profil
 	if qr, ok := raw["queryResult"]; ok {
 		result.Results = qr
 	}
-	if agent != "" {
-		result.Agent = agent
-	}
 
 	return result, nil
 }
@@ -139,7 +249,7 @@ func (c *Client) AskQueryDataRaw(ctx context.Context, token string, profile *pro
 	reqBody := map[string]interface{}{
 		"prompt": question,
 		"context": map[string]interface{}{
-			"datasourceReferences": buildDatasourceReferences(profile, ""),
+			"datasourceReferences": buildQueryDataDatasourceRef(profile),
 		},
 		"generationOptions": map[string]interface{}{
 			"generateQueryResult": true,
@@ -151,7 +261,7 @@ func (c *Client) AskQueryDataRaw(ctx context.Context, token string, profile *pro
 		return nil, fmt.Errorf("marshaling queryData request: %w", err)
 	}
 
-	apiURL := fmt.Sprintf(queryDataURL, profile.Project, location)
+	apiURL := fmt.Sprintf(queryDataURLFmt, profile.Project, location)
 	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("creating queryData request: %w", err)
@@ -184,6 +294,8 @@ func (c *Client) AskQueryDataRaw(ctx context.Context, token string, profile *pro
 // CreateAgent creates a new BigQuery data agent via the Data Agents v1alpha API.
 // The API returns a long-running Operation; we surface the operation name.
 // Docs: https://docs.cloud.google.com/gemini/data-agents/reference/rest/v1alpha/projects.locations.dataAgents/create
+// CreateAgent creates a data agent synchronously via :createSync.
+// Uses publishedContext (not stagingContext) matching the Rust implementation.
 func (c *Client) CreateAgent(ctx context.Context, token, projectID, location string, opts CreateAgentOpts) (*CreateAgentResult, error) {
 	if projectID == "" {
 		return nil, fmt.Errorf("project ID is required")
@@ -192,24 +304,27 @@ func (c *Client) CreateAgent(ctx context.Context, token, projectID, location str
 		location = "us"
 	}
 
-	// Build the DataAgent request body with the documented nested structure.
-	tableRefs := make([]BigQueryTableReference, 0, len(opts.Tables)+len(opts.Views))
-	for _, ref := range append(opts.Tables, opts.Views...) {
-		tableRefs = append(tableRefs, parseBQTableRef(ref))
+	tableRefs := buildBQTableRefs(strings.Join(opts.Tables, ","))
+	for _, v := range opts.Views {
+		tableRefs = append(tableRefs, parseBQTableRefMap(v))
 	}
 
-	agentBody := DataAgent{
-		DisplayName: opts.AgentID,
-		DataAnalyticsAgent: &DataAnalyticsAgent{
-			StagingContext: &AgentContext{
-				SystemInstruction: opts.Instructions,
-				DatasourceReferences: &DatasourceReferences{
-					BQ: &BigQueryTableReferences{
-						TableReferences: tableRefs,
-					},
-				},
-				ExampleQueries: opts.ExampleQueries,
+	publishedContext := map[string]interface{}{
+		"datasourceReferences": map[string]interface{}{
+			"bq": map[string]interface{}{
+				"tableReferences": tableRefs,
 			},
+		},
+		"exampleQueries": opts.ExampleQueries,
+	}
+	if opts.Instructions != "" {
+		publishedContext["systemInstruction"] = opts.Instructions
+	}
+
+	agentBody := map[string]interface{}{
+		"displayName": opts.DisplayName,
+		"dataAnalyticsAgent": map[string]interface{}{
+			"publishedContext": publishedContext,
 		},
 	}
 
@@ -218,11 +333,7 @@ func (c *Client) CreateAgent(ctx context.Context, token, projectID, location str
 		return nil, fmt.Errorf("marshaling create-agent request: %w", err)
 	}
 
-	// dataAgentId is a query parameter, not in the body.
-	apiURL := fmt.Sprintf(dataAgentsBaseURL, projectID, location)
-	if opts.AgentID != "" {
-		apiURL += "?dataAgentId=" + opts.AgentID
-	}
+	apiURL := fmt.Sprintf(createAgentSyncFmt, projectID, location, opts.AgentID)
 
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(body))
 	if err != nil {
@@ -230,6 +341,7 @@ func (c *Client) CreateAgent(ctx context.Context, token, projectID, location str
 	}
 	httpReq.Header.Set("Authorization", "Bearer "+token)
 	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-server-timeout", "300")
 
 	resp, err := c.HTTPClient.Do(httpReq)
 	if err != nil {
@@ -241,23 +353,23 @@ func (c *Client) CreateAgent(ctx context.Context, token, projectID, location str
 		return nil, readAPIError(resp)
 	}
 
-	// Response is a long-running Operation.
+	// :createSync returns the DataAgent directly (not an Operation).
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading create-agent response: %w", err)
 	}
 
-	var operation map[string]interface{}
-	if err := json.Unmarshal(respBody, &operation); err != nil {
+	var agent map[string]interface{}
+	if err := json.Unmarshal(respBody, &agent); err != nil {
 		return nil, fmt.Errorf("parsing create-agent response: %w", err)
 	}
 
-	opName, _ := operation["name"].(string)
+	name, _ := agent["name"].(string)
 
 	return &CreateAgentResult{
-		OperationName: opName,
+		OperationName: name,
 		AgentID:       opts.AgentID,
-		Status:        "operation_started",
+		Status:        "created",
 	}, nil
 }
 
@@ -271,7 +383,7 @@ func (c *Client) ListAgents(ctx context.Context, token, projectID, location stri
 		location = "us"
 	}
 
-	baseURL := fmt.Sprintf(dataAgentsBaseURL, projectID, location)
+	baseURL := fmt.Sprintf(dataAgentsURLFmt, projectID, location)
 	var allAgents []AgentSummary
 	pageToken := ""
 
@@ -351,6 +463,8 @@ func extractErrorMessage(body []byte, statusCode int) string {
 // There is no standalone addVerifiedQuery method in the API; verified queries
 // (exampleQueries) are fields on the DataAgent resource updated via patch.
 // Docs: https://docs.cloud.google.com/gemini/data-agents/reference/rest/v1alpha/projects.locations.dataAgents
+// AddVerifiedQuery appends example queries to an existing agent via GET + :updateSync.
+// Uses publishedContext (matching Rust implementation).
 func (c *Client) AddVerifiedQuery(ctx context.Context, token, projectID, location string, opts PatchAgentOpts) (*AddVerifiedQueryResult, error) {
 	if projectID == "" {
 		return nil, fmt.Errorf("project ID is required")
@@ -359,9 +473,9 @@ func (c *Client) AddVerifiedQuery(ctx context.Context, token, projectID, locatio
 		location = "us"
 	}
 
-	// First GET the existing agent to read current exampleQueries.
+	// 1. GET the existing agent to read current exampleQueries.
 	agentResourceName := fmt.Sprintf("projects/%s/locations/%s/dataAgents/%s", projectID, location, opts.AgentName)
-	getURL := fmt.Sprintf(dataAgentURL, agentResourceName)
+	getURL := fmt.Sprintf(dataAgentURLFmt, agentResourceName)
 
 	getReq, err := http.NewRequestWithContext(ctx, "GET", getURL, nil)
 	if err != nil {
@@ -385,42 +499,57 @@ func (c *Client) AddVerifiedQuery(ctx context.Context, token, projectID, locatio
 		return nil, fmt.Errorf("reading get response: %w", err)
 	}
 
-	var existing DataAgent
-	if err := json.Unmarshal(getBody, &existing); err != nil {
+	// 2. Parse existing agent and append new exampleQueries to publishedContext.
+	var agent map[string]interface{}
+	if err := json.Unmarshal(getBody, &agent); err != nil {
 		return nil, fmt.Errorf("parsing existing agent: %w", err)
 	}
 
-	// Append new example queries to staging context.
-	if existing.DataAnalyticsAgent == nil {
-		existing.DataAnalyticsAgent = &DataAnalyticsAgent{}
+	daa, _ := agent["dataAnalyticsAgent"].(map[string]interface{})
+	if daa == nil {
+		daa = map[string]interface{}{}
 	}
-	if existing.DataAnalyticsAgent.StagingContext == nil {
-		existing.DataAnalyticsAgent.StagingContext = &AgentContext{}
+	published, _ := daa["publishedContext"].(map[string]interface{})
+	if published == nil {
+		published = map[string]interface{}{}
 	}
-	existing.DataAnalyticsAgent.StagingContext.ExampleQueries = append(
-		existing.DataAnalyticsAgent.StagingContext.ExampleQueries,
-		opts.ExampleQueries...,
-	)
 
-	// PATCH the agent with updated exampleQueries.
-	patchBody, err := json.Marshal(existing)
+	existingQueries, _ := published["exampleQueries"].([]interface{})
+	for _, eq := range opts.ExampleQueries {
+		existingQueries = append(existingQueries, map[string]interface{}{
+			"naturalLanguageQuestion": eq.NaturalLanguageQuestion,
+			"sqlQuery":               eq.SQLQuery,
+		})
+	}
+	published["exampleQueries"] = existingQueries
+
+	// 3. :updateSync with the updated publishedContext.
+	updateBody := map[string]interface{}{
+		"name": agentResourceName,
+		"dataAnalyticsAgent": map[string]interface{}{
+			"publishedContext": published,
+		},
+	}
+
+	patchBody, err := json.Marshal(updateBody)
 	if err != nil {
-		return nil, fmt.Errorf("marshaling patch request: %w", err)
+		return nil, fmt.Errorf("marshaling update request: %w", err)
 	}
 
-	patchURL := fmt.Sprintf(dataAgentURL, agentResourceName) +
-		"?updateMask=dataAnalyticsAgent.stagingContext.exampleQueries"
+	updateURL := fmt.Sprintf(updateAgentSyncFmt, agentResourceName,
+		"dataAnalyticsAgent.publishedContext.exampleQueries")
 
-	patchReq, err := http.NewRequestWithContext(ctx, "PATCH", patchURL, bytes.NewReader(patchBody))
+	patchReq, err := http.NewRequestWithContext(ctx, "PATCH", updateURL, bytes.NewReader(patchBody))
 	if err != nil {
-		return nil, fmt.Errorf("creating patch request: %w", err)
+		return nil, fmt.Errorf("creating update request: %w", err)
 	}
 	patchReq.Header.Set("Authorization", "Bearer "+token)
 	patchReq.Header.Set("Content-Type", "application/json")
+	patchReq.Header.Set("x-server-timeout", "300")
 
 	patchResp, err := c.HTTPClient.Do(patchReq)
 	if err != nil {
-		return nil, fmt.Errorf("patch agent failed: %w", err)
+		return nil, fmt.Errorf("updateSync agent failed: %w", err)
 	}
 	defer patchResp.Body.Close()
 
@@ -428,30 +557,13 @@ func (c *Client) AddVerifiedQuery(ctx context.Context, token, projectID, locatio
 		return nil, readAPIError(patchResp)
 	}
 
-	// PATCH returns a long-running Operation, not the updated agent.
-	patchRespBody, err := io.ReadAll(patchResp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading patch response: %w", err)
-	}
-
-	var patchOp map[string]interface{}
-	if err := json.Unmarshal(patchRespBody, &patchOp); err != nil {
-		return nil, fmt.Errorf("parsing patch response: %w", err)
-	}
-
-	opName, _ := patchOp["name"].(string)
-	done, _ := patchOp["done"].(bool)
-
-	status := "operation_started"
-	if done {
-		status = "completed"
-	}
+	total := len(existingQueries)
 
 	return &AddVerifiedQueryResult{
-		Agent:         opts.AgentName,
-		QueriesAdded:  len(opts.ExampleQueries),
-		OperationName: opName,
-		Status:        status,
+		Agent:              opts.AgentName,
+		QueriesAdded:       len(opts.ExampleQueries),
+		TotalVerifiedQueries: total,
+		Status:             "added",
 	}, nil
 }
 
@@ -495,69 +607,153 @@ func parseBQTableRef(ref string) BigQueryTableReference {
 
 // buildDatasourceReferences constructs the correct nested datasource
 // reference for the queryData API based on the profile's source type.
-func buildDatasourceReferences(profile *profiles.Profile, inlineTables string) map[string]interface{} {
-	if profile == nil {
-		return nil
+// buildBQTableRefs parses a comma-separated table list into reference maps.
+func buildBQTableRefs(tables string) []map[string]string {
+	var refs []map[string]string
+	for _, ref := range strings.Split(tables, ",") {
+		trimmed := strings.TrimSpace(ref)
+		if trimmed != "" {
+			refs = append(refs, parseBQTableRefMap(trimmed))
+		}
+	}
+	return refs
+}
+
+// buildLookerExploreRefs builds explore reference objects from a profile.
+func buildLookerExploreRefs(profile *profiles.Profile) []map[string]interface{} {
+	instanceURL := profile.LookerInstanceURL
+	explores := profile.LookerExplores
+	var refs []map[string]interface{}
+	for _, exp := range explores {
+		parts := strings.SplitN(exp, "/", 2)
+		if len(parts) == 2 {
+			ref := map[string]interface{}{
+				"lookerInstanceUri": instanceURL,
+				"lookmlModel":      parts[0],
+				"explore":          parts[1],
+			}
+			refs = append(refs, ref)
+		}
+	}
+	return refs
+}
+
+// buildQueryDataDatasourceRef builds the datasourceReferences for the
+// queryData endpoint, matching the Rust implementation's per-source structures.
+func buildQueryDataDatasourceRef(profile *profiles.Profile) map[string]interface{} {
+	location := profile.Location
+	if location == "" {
+		location = "us"
 	}
 
 	switch profile.SourceType {
-	case profiles.BigQuery:
-		var tableRefs []map[string]string
-		if inlineTables != "" {
-			for _, ref := range strings.Split(inlineTables, ",") {
-				tableRefs = append(tableRefs, parseBQTableRefMap(strings.TrimSpace(ref)))
-			}
-		}
-		return map[string]interface{}{
-			"bq": map[string]interface{}{
-				"tableReferences": tableRefs,
-			},
-		}
-
-	case profiles.Spanner:
-		return map[string]interface{}{
-			"spannerReference": map[string]interface{}{
-				"projectId":  profile.Project,
-				"instanceId": profile.InstanceID,
-				"databaseId": profile.DatabaseID,
-			},
-		}
-
 	case profiles.AlloyDB:
-		return map[string]interface{}{
-			"alloydb": map[string]interface{}{
+		inner := map[string]interface{}{
+			"databaseReference": map[string]interface{}{
 				"projectId":  profile.Project,
-				"locationId": profile.Location,
+				"region":     location,
 				"clusterId":  profile.ClusterID,
 				"instanceId": profile.InstanceID,
 				"databaseId": profile.DatabaseID,
 			},
 		}
+		if profile.ContextSetID != "" {
+			inner["agentContextReference"] = map[string]interface{}{
+				"contextSetId": fmt.Sprintf("projects/%s/locations/%s/contextSets/%s",
+					profile.Project, location, profile.ContextSetID),
+			}
+		}
+		return map[string]interface{}{"alloydb": inner}
 
-	case profiles.CloudSQL:
-		return map[string]interface{}{
-			"cloudSqlReference": map[string]interface{}{
+	case profiles.Spanner:
+		inner := map[string]interface{}{
+			"databaseReference": map[string]interface{}{
+				"engine":     "GOOGLE_SQL",
 				"projectId":  profile.Project,
 				"instanceId": profile.InstanceID,
 				"databaseId": profile.DatabaseID,
 			},
 		}
+		if profile.ContextSetID != "" {
+			inner["agentContextReference"] = map[string]interface{}{
+				"contextSetId": fmt.Sprintf("projects/%s/locations/%s/contextSets/%s",
+					profile.Project, location, profile.ContextSetID),
+			}
+		}
+		return map[string]interface{}{"spannerReference": inner}
 
-	case profiles.Looker:
-		ref := map[string]interface{}{}
-		if profile.LookerInstanceURL != "" {
-			ref["instanceUri"] = profile.LookerInstanceURL
+	case profiles.CloudSQL:
+		engine := "POSTGRESQL"
+		if profile.DBType == "mysql" {
+			engine = "MYSQL"
 		}
-		if len(profile.LookerExplores) > 0 {
-			ref["exploreReferences"] = profile.LookerExplores
+		inner := map[string]interface{}{
+			"databaseReference": map[string]interface{}{
+				"engine":     engine,
+				"projectId":  profile.Project,
+				"region":     location,
+				"instanceId": profile.InstanceID,
+				"databaseId": profile.DatabaseID,
+			},
 		}
-		return map[string]interface{}{
-			"looker": ref,
+		if profile.ContextSetID != "" {
+			inner["agentContextReference"] = map[string]interface{}{
+				"contextSetId": fmt.Sprintf("projects/%s/locations/%s/contextSets/%s",
+					profile.Project, location, profile.ContextSetID),
+			}
 		}
+		return map[string]interface{}{"cloudSqlReference": inner}
 
 	default:
 		return nil
 	}
+}
+
+// parseChatResponse parses the streaming chat response (JSON array of messages)
+// and extracts the CA answer.
+func parseChatResponse(body []byte, question, agent string) (*AskResult, error) {
+	// The chat API returns a JSON array or newline-delimited JSON messages.
+	var messages []map[string]interface{}
+
+	trimmed := strings.TrimSpace(string(body))
+	if strings.HasPrefix(trimmed, "[") {
+		if err := json.Unmarshal([]byte(trimmed), &messages); err != nil {
+			return nil, fmt.Errorf("parsing chat response: %w", err)
+		}
+	} else {
+		// Newline-delimited JSON.
+		for _, line := range strings.Split(trimmed, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			var msg map[string]interface{}
+			if err := json.Unmarshal([]byte(line), &msg); err != nil {
+				continue
+			}
+			messages = append(messages, msg)
+		}
+	}
+
+	result := &AskResult{
+		Question: question,
+		Agent:    agent,
+	}
+
+	// Extract SQL, results, and explanation from the streaming messages.
+	for _, msg := range messages {
+		if sql, ok := msg["generatedQuery"].(string); ok && sql != "" {
+			result.SQL = sql
+		}
+		if explanation, ok := msg["textContent"].(string); ok && explanation != "" {
+			result.Explanation = explanation
+		}
+		if qr, ok := msg["queryResult"]; ok {
+			result.Results = qr
+		}
+	}
+
+	return result, nil
 }
 
 func parseBQTableRefMap(ref string) map[string]string {

--- a/internal/ca/client.go
+++ b/internal/ca/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/haiyuan-eng-google/dcx-cli/internal/profiles"
@@ -294,14 +295,12 @@ func (c *Client) AskQueryDataRaw(ctx context.Context, token string, profile *pro
 
 // CreateAgent creates a data agent synchronously via :createSync.
 // Uses publishedContext (not stagingContext) matching the Rust implementation.
-// Agent management uses locations/global (not regional like chat/queryData).
-func (c *Client) CreateAgent(ctx context.Context, token, projectID, location string, opts CreateAgentOpts) (*CreateAgentResult, error) {
+// Agent management always uses locations/global; regional locations are rejected by the API.
+func (c *Client) CreateAgent(ctx context.Context, token, projectID, _ string, opts CreateAgentOpts) (*CreateAgentResult, error) {
 	if projectID == "" {
 		return nil, fmt.Errorf("project ID is required")
 	}
-	if location == "" {
-		location = "global"
-	}
+	location := "global"
 
 	tableRefs := buildBQTableRefs(strings.Join(opts.Tables, ","))
 	for _, v := range opts.Views {
@@ -373,14 +372,12 @@ func (c *Client) CreateAgent(ctx context.Context, token, projectID, location str
 }
 
 // ListAgents lists all data agents in the given project, handling pagination.
-// Agent management uses locations/global (not regional like chat/queryData).
-func (c *Client) ListAgents(ctx context.Context, token, projectID, location string) (*AgentsListResult, error) {
+// Agent management always uses locations/global; regional locations are rejected by the API.
+func (c *Client) ListAgents(ctx context.Context, token, projectID, _ string) (*AgentsListResult, error) {
 	if projectID == "" {
 		return nil, fmt.Errorf("project ID is required")
 	}
-	if location == "" {
-		location = "global"
-	}
+	location := "global"
 
 	baseURL := fmt.Sprintf(dataAgentsURLFmt, projectID, location)
 	var allAgents []AgentSummary
@@ -389,7 +386,7 @@ func (c *Client) ListAgents(ctx context.Context, token, projectID, location stri
 	for {
 		apiURL := baseURL
 		if pageToken != "" {
-			apiURL += "?pageToken=" + pageToken
+			apiURL += "?pageToken=" + url.QueryEscape(pageToken)
 		}
 
 		httpReq, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
@@ -460,14 +457,12 @@ func extractErrorMessage(body []byte, statusCode int) string {
 
 // AddVerifiedQuery appends example queries to an existing agent via GET + :updateSync.
 // Uses publishedContext (matching Rust implementation).
-// Agent management uses locations/global (not regional like chat/queryData).
-func (c *Client) AddVerifiedQuery(ctx context.Context, token, projectID, location string, opts PatchAgentOpts) (*AddVerifiedQueryResult, error) {
+// Agent management always uses locations/global; regional locations are rejected by the API.
+func (c *Client) AddVerifiedQuery(ctx context.Context, token, projectID, _ string, opts PatchAgentOpts) (*AddVerifiedQueryResult, error) {
 	if projectID == "" {
 		return nil, fmt.Errorf("project ID is required")
 	}
-	if location == "" {
-		location = "global"
-	}
+	location := "global"
 
 	// 1. GET the existing agent to read current exampleQueries.
 	agentResourceName := fmt.Sprintf("projects/%s/locations/%s/dataAgents/%s", projectID, location, opts.AgentName)

--- a/internal/ca/client.go
+++ b/internal/ca/client.go
@@ -710,9 +710,12 @@ func buildQueryDataDatasourceRef(profile *profiles.Profile) map[string]interface
 }
 
 // parseChatResponse parses the streaming chat response (JSON array of messages)
-// and extracts the CA answer.
+// and extracts the CA answer. The response is an array of objects like:
+//
+//	{"systemMessage": {"text": {"parts": [...], "textType": "FINAL_RESPONSE"}}}
+//	{"systemMessage": {"data": {"generatedSql": "SELECT ..."}}}
+//	{"systemMessage": {"data": {"result": {"data": [...], "schema": {...}}}}}
 func parseChatResponse(body []byte, question, agent string) (*AskResult, error) {
-	// The chat API returns a JSON array or newline-delimited JSON messages.
 	var messages []map[string]interface{}
 
 	trimmed := strings.TrimSpace(string(body))
@@ -721,10 +724,9 @@ func parseChatResponse(body []byte, question, agent string) (*AskResult, error) 
 			return nil, fmt.Errorf("parsing chat response: %w", err)
 		}
 	} else {
-		// Newline-delimited JSON.
 		for _, line := range strings.Split(trimmed, "\n") {
 			line = strings.TrimSpace(line)
-			if line == "" {
+			if line == "" || line == "," {
 				continue
 			}
 			var msg map[string]interface{}
@@ -740,16 +742,38 @@ func parseChatResponse(body []byte, question, agent string) (*AskResult, error) 
 		Agent:    agent,
 	}
 
-	// Extract SQL, results, and explanation from the streaming messages.
 	for _, msg := range messages {
-		if sql, ok := msg["generatedQuery"].(string); ok && sql != "" {
-			result.SQL = sql
+		sm, ok := msg["systemMessage"].(map[string]interface{})
+		if !ok {
+			continue
 		}
-		if explanation, ok := msg["textContent"].(string); ok && explanation != "" {
-			result.Explanation = explanation
+
+		// Extract text messages (FINAL_RESPONSE).
+		if text, ok := sm["text"].(map[string]interface{}); ok {
+			textType, _ := text["textType"].(string)
+			if textType == "FINAL_RESPONSE" {
+				if parts, ok := text["parts"].([]interface{}); ok {
+					for _, p := range parts {
+						if s, ok := p.(string); ok {
+							if result.Explanation == "" {
+								result.Explanation = s
+							} else {
+								result.Explanation += "\n" + s
+							}
+						}
+					}
+				}
+			}
 		}
-		if qr, ok := msg["queryResult"]; ok {
-			result.Results = qr
+
+		// Extract data messages (generatedSql, result).
+		if data, ok := sm["data"].(map[string]interface{}); ok {
+			if sql, ok := data["generatedSql"].(string); ok {
+				result.SQL = sql
+			}
+			if qr, ok := data["result"]; ok {
+				result.Results = qr
+			}
 		}
 	}
 

--- a/internal/ca/client.go
+++ b/internal/ca/client.go
@@ -13,14 +13,13 @@ import (
 )
 
 const (
-	// CA Chat API endpoint (BigQuery DataAgent).
-	chatAPIURL = "https://datacatalog.googleapis.com/v1/projects/%s/locations/%s/dataAgents:chat"
+	// All CA endpoints are on the geminidataanalytics v1alpha API.
+	// Docs: https://docs.cloud.google.com/gemini/data-agents/reference/rest/v1alpha
 
-	// CA QueryData API endpoint (Spanner, AlloyDB, Cloud SQL).
-	queryDataAPIURL = "https://datacatalog.googleapis.com/v1/projects/%s/locations/%s:queryData"
+	// queryData: NL-to-SQL for all source types (BigQuery, Spanner, AlloyDB, Cloud SQL, Looker).
+	queryDataURL = "https://geminidataanalytics.googleapis.com/v1alpha/projects/%s/locations/%s:queryData"
 
-	// Data Agents management API (v1alpha).
-	// Docs: https://docs.cloud.google.com/gemini/data-agents/reference/rest/v1alpha/projects.locations.dataAgents
+	// Data Agents management endpoints.
 	dataAgentsBaseURL = "https://geminidataanalytics.googleapis.com/v1alpha/projects/%s/locations/%s/dataAgents"
 	dataAgentURL      = "https://geminidataanalytics.googleapis.com/v1alpha/%s" // takes full resource name
 )
@@ -38,18 +37,13 @@ func NewClient(httpClient *http.Client) *Client {
 	return &Client{HTTPClient: httpClient}
 }
 
-// Ask routes a question to the appropriate CA API based on profile source type.
+// Ask sends a question to the queryData endpoint, routing to the correct
+// datasource type based on the profile. All source types use the same
+// geminidataanalytics.googleapis.com/v1alpha queryData endpoint.
+// Docs: https://docs.cloud.google.com/gemini/data-agents/reference/rest/v1alpha/projects.locations/queryData
 func (c *Client) Ask(ctx context.Context, token string, profile *profiles.Profile, question, agent, tables string) (*AskResult, error) {
-	if profile != nil && profile.IsQueryDataSource() {
-		return c.askQueryData(ctx, token, profile, question)
-	}
-	return c.askChat(ctx, token, profile, question, agent, tables)
-}
-
-// askChat sends a question to the CA Chat API (BigQuery/Looker DataAgent).
-func (c *Client) askChat(ctx context.Context, token string, profile *profiles.Profile, question, agent, tables string) (*AskResult, error) {
 	projectID := ""
-	location := "us" // default location for CA
+	location := "us"
 	if profile != nil {
 		projectID = profile.Project
 		if profile.Location != "" {
@@ -60,144 +54,78 @@ func (c *Client) askChat(ctx context.Context, token string, profile *profiles.Pr
 		return nil, fmt.Errorf("project ID is required for ca ask")
 	}
 
-	url := fmt.Sprintf(chatAPIURL, projectID, location)
-
+	// Build the queryData request with the documented schema.
 	reqBody := map[string]interface{}{
-		"question": question,
+		"prompt": question,
+		"context": map[string]interface{}{
+			"datasourceReferences": buildDatasourceReferences(profile, tables),
+		},
+		"generationOptions": map[string]interface{}{
+			"generateQueryResult":           true,
+			"generateNaturalLanguageAnswer": true,
+			"generateExplanation":           true,
+		},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling queryData request: %w", err)
+	}
+
+	apiURL := fmt.Sprintf(queryDataURL, projectID, location)
+	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating queryData request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("queryData API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, readAPIError(resp)
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading queryData response: %w", err)
+	}
+
+	// Parse the documented QueryDataResponse.
+	var raw map[string]interface{}
+	if err := json.Unmarshal(respBody, &raw); err != nil {
+		return nil, fmt.Errorf("parsing queryData response: %w", err)
+	}
+
+	sql, _ := raw["generatedQuery"].(string)
+	explanation, _ := raw["intentExplanation"].(string)
+	nlAnswer, _ := raw["naturalLanguageAnswer"].(string)
+
+	result := &AskResult{
+		Question:    question,
+		SQL:         sql,
+		Explanation: explanation,
+		Source:      sourceName(profile.SourceType),
+	}
+	if nlAnswer != "" {
+		result.Explanation = nlAnswer
+	}
+	if qr, ok := raw["queryResult"]; ok {
+		result.Results = qr
 	}
 	if agent != "" {
-		reqBody["agent"] = agent
-	}
-	if tables != "" {
-		reqBody["tables"] = tables
-	}
-	// Looker profile: pass explores context.
-	if profile != nil && profile.SourceType == profiles.Looker {
-		if profile.LookerInstanceURL != "" {
-			reqBody["looker_instance_url"] = profile.LookerInstanceURL
-		}
-		if len(profile.LookerExplores) > 0 {
-			reqBody["looker_explores"] = profile.LookerExplores
-		}
+		result.Agent = agent
 	}
 
-	body, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling chat request: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("creating chat request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.HTTPClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("chat API request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 400 {
-		return nil, readAPIError(resp)
-	}
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading chat response: %w", err)
-	}
-
-	var chatResp ChatResponse
-	if err := json.Unmarshal(respBody, &chatResp); err != nil {
-		return nil, fmt.Errorf("parsing chat response: %w", err)
-	}
-
-	source := "BigQuery"
-	if profile != nil && profile.SourceType == profiles.Looker {
-		source = "Looker"
-	}
-
-	return &AskResult{
-		Question:    chatResp.Question,
-		SQL:         chatResp.SQL,
-		Results:     chatResp.Results,
-		Explanation: chatResp.Explanation,
-		Source:      source,
-		Agent:       chatResp.Agent,
-	}, nil
+	return result, nil
 }
 
-// askQueryData sends a question to the CA QueryData API (Spanner/AlloyDB/CloudSQL).
-func (c *Client) askQueryData(ctx context.Context, token string, profile *profiles.Profile, question string) (*AskResult, error) {
-	if profile.Project == "" {
-		return nil, fmt.Errorf("project is required in profile")
-	}
-
-	location := profile.Location
-	if location == "" {
-		location = "us"
-	}
-
-	url := fmt.Sprintf(queryDataAPIURL, profile.Project, location)
-
-	reqBody := QueryDataRequest{
-		Question:   question,
-		ProjectID:  profile.Project,
-		SourceType: string(profile.SourceType),
-		Location:   profile.Location,
-		InstanceID: profile.InstanceID,
-		DatabaseID: profile.DatabaseID,
-		ClusterID:  profile.ClusterID,
-		DBType:     profile.DBType,
-	}
-	if profile.ContextSetID != "" {
-		reqBody.AgentContextReference = profile.ContextSetID
-	}
-
-	body, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling querydata request: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("creating querydata request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.HTTPClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("querydata API request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 400 {
-		return nil, readAPIError(resp)
-	}
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading querydata response: %w", err)
-	}
-
-	var qdResp QueryDataResponse
-	if err := json.Unmarshal(respBody, &qdResp); err != nil {
-		return nil, fmt.Errorf("parsing querydata response: %w", err)
-	}
-
-	return &AskResult{
-		Question:    qdResp.Question,
-		SQL:         qdResp.SQL,
-		Results:     qdResp.Results,
-		Explanation: qdResp.Explanation,
-		Source:      sourceName(profile.SourceType),
-	}, nil
-}
-
-// AskQueryDataRaw executes a raw SQL-like question via QueryData and returns
-// the raw response. Used by database helpers (schema describe, databases list).
+// AskQueryDataRaw executes a question via queryData and returns the raw
+// response. Used by database helpers (schema describe, databases list).
 func (c *Client) AskQueryDataRaw(ctx context.Context, token string, profile *profiles.Profile, question string) (map[string]interface{}, error) {
 	if profile.Project == "" {
 		return nil, fmt.Errorf("project is required in profile")
@@ -208,37 +136,32 @@ func (c *Client) AskQueryDataRaw(ctx context.Context, token string, profile *pro
 		location = "us"
 	}
 
-	url := fmt.Sprintf(queryDataAPIURL, profile.Project, location)
-
-	reqBody := QueryDataRequest{
-		Question:   question,
-		ProjectID:  profile.Project,
-		SourceType: string(profile.SourceType),
-		Location:   profile.Location,
-		InstanceID: profile.InstanceID,
-		DatabaseID: profile.DatabaseID,
-		ClusterID:  profile.ClusterID,
-		DBType:     profile.DBType,
-	}
-	if profile.ContextSetID != "" {
-		reqBody.AgentContextReference = profile.ContextSetID
+	reqBody := map[string]interface{}{
+		"prompt": question,
+		"context": map[string]interface{}{
+			"datasourceReferences": buildDatasourceReferences(profile, ""),
+		},
+		"generationOptions": map[string]interface{}{
+			"generateQueryResult": true,
+		},
 	}
 
 	body, err := json.Marshal(reqBody)
 	if err != nil {
-		return nil, fmt.Errorf("marshaling querydata request: %w", err)
+		return nil, fmt.Errorf("marshaling queryData request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	apiURL := fmt.Sprintf(queryDataURL, profile.Project, location)
+	req, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("creating querydata request: %w", err)
+		return nil, fmt.Errorf("creating queryData request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("querydata API request failed: %w", err)
+		return nil, fmt.Errorf("queryData API request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -248,12 +171,12 @@ func (c *Client) AskQueryDataRaw(ctx context.Context, token string, profile *pro
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("reading querydata response: %w", err)
+		return nil, fmt.Errorf("reading queryData response: %w", err)
 	}
 
 	var raw map[string]interface{}
 	if err := json.Unmarshal(respBody, &raw); err != nil {
-		return nil, fmt.Errorf("parsing querydata response: %w", err)
+		return nil, fmt.Errorf("parsing queryData response: %w", err)
 	}
 	return raw, nil
 }
@@ -567,6 +490,85 @@ func parseBQTableRef(ref string) BigQueryTableReference {
 		return BigQueryTableReference{DatasetID: parts[0], TableID: parts[1]}
 	default:
 		return BigQueryTableReference{TableID: ref}
+	}
+}
+
+// buildDatasourceReferences constructs the correct nested datasource
+// reference for the queryData API based on the profile's source type.
+func buildDatasourceReferences(profile *profiles.Profile, inlineTables string) map[string]interface{} {
+	if profile == nil {
+		return nil
+	}
+
+	switch profile.SourceType {
+	case profiles.BigQuery:
+		var tableRefs []map[string]string
+		if inlineTables != "" {
+			for _, ref := range strings.Split(inlineTables, ",") {
+				tableRefs = append(tableRefs, parseBQTableRefMap(strings.TrimSpace(ref)))
+			}
+		}
+		return map[string]interface{}{
+			"bq": map[string]interface{}{
+				"tableReferences": tableRefs,
+			},
+		}
+
+	case profiles.Spanner:
+		return map[string]interface{}{
+			"spannerReference": map[string]interface{}{
+				"projectId":  profile.Project,
+				"instanceId": profile.InstanceID,
+				"databaseId": profile.DatabaseID,
+			},
+		}
+
+	case profiles.AlloyDB:
+		return map[string]interface{}{
+			"alloydb": map[string]interface{}{
+				"projectId":  profile.Project,
+				"locationId": profile.Location,
+				"clusterId":  profile.ClusterID,
+				"instanceId": profile.InstanceID,
+				"databaseId": profile.DatabaseID,
+			},
+		}
+
+	case profiles.CloudSQL:
+		return map[string]interface{}{
+			"cloudSqlReference": map[string]interface{}{
+				"projectId":  profile.Project,
+				"instanceId": profile.InstanceID,
+				"databaseId": profile.DatabaseID,
+			},
+		}
+
+	case profiles.Looker:
+		ref := map[string]interface{}{}
+		if profile.LookerInstanceURL != "" {
+			ref["instanceUri"] = profile.LookerInstanceURL
+		}
+		if len(profile.LookerExplores) > 0 {
+			ref["exploreReferences"] = profile.LookerExplores
+		}
+		return map[string]interface{}{
+			"looker": ref,
+		}
+
+	default:
+		return nil
+	}
+}
+
+func parseBQTableRefMap(ref string) map[string]string {
+	parts := strings.SplitN(ref, ".", 3)
+	switch len(parts) {
+	case 3:
+		return map[string]string{"projectId": parts[0], "datasetId": parts[1], "tableId": parts[2]}
+	case 2:
+		return map[string]string{"datasetId": parts[0], "tableId": parts[1]}
+	default:
+		return map[string]string{"tableId": ref}
 	}
 }
 

--- a/internal/ca/client.go
+++ b/internal/ca/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/haiyuan-eng-google/dcx-cli/internal/profiles"
 )
@@ -18,10 +19,10 @@ const (
 	// CA QueryData API endpoint (Spanner, AlloyDB, Cloud SQL).
 	queryDataAPIURL = "https://datacatalog.googleapis.com/v1/projects/%s/locations/%s:queryData"
 
-	// CA DataAgent management endpoints.
-	createAgentURL       = "https://datacatalog.googleapis.com/v1/projects/%s/locations/%s/dataAgents"
-	listAgentsURL        = "https://datacatalog.googleapis.com/v1/projects/%s/locations/%s/dataAgents"
-	addVerifiedQueryURL  = "https://datacatalog.googleapis.com/v1/projects/%s/locations/%s/dataAgents/%s:addVerifiedQuery"
+	// Data Agents management API (v1alpha).
+	// Docs: https://docs.cloud.google.com/gemini/data-agents/reference/rest/v1alpha/projects.locations.dataAgents
+	dataAgentsBaseURL = "https://geminidataanalytics.googleapis.com/v1alpha/projects/%s/locations/%s/dataAgents"
+	dataAgentURL      = "https://geminidataanalytics.googleapis.com/v1alpha/%s" // takes full resource name
 )
 
 // Client provides access to the Conversational Analytics APIs.
@@ -257,8 +258,10 @@ func (c *Client) AskQueryDataRaw(ctx context.Context, token string, profile *pro
 	return raw, nil
 }
 
-// CreateAgent creates a new BigQuery data agent.
-func (c *Client) CreateAgent(ctx context.Context, token, projectID, location string, req CreateAgentRequest) (*CreateAgentResult, error) {
+// CreateAgent creates a new BigQuery data agent via the Data Agents v1alpha API.
+// The API returns a long-running Operation; we surface the operation name.
+// Docs: https://docs.cloud.google.com/gemini/data-agents/reference/rest/v1alpha/projects.locations.dataAgents/create
+func (c *Client) CreateAgent(ctx context.Context, token, projectID, location string, opts CreateAgentOpts) (*CreateAgentResult, error) {
 	if projectID == "" {
 		return nil, fmt.Errorf("project ID is required")
 	}
@@ -266,14 +269,39 @@ func (c *Client) CreateAgent(ctx context.Context, token, projectID, location str
 		location = "us"
 	}
 
-	url := fmt.Sprintf(createAgentURL, projectID, location)
+	// Build the DataAgent request body with the documented nested structure.
+	tableRefs := make([]BigQueryTableReference, 0, len(opts.Tables)+len(opts.Views))
+	for _, ref := range append(opts.Tables, opts.Views...) {
+		tableRefs = append(tableRefs, parseBQTableRef(ref))
+	}
 
-	body, err := json.Marshal(req)
+	agentBody := DataAgent{
+		DisplayName: opts.AgentID,
+		DataAnalyticsAgent: &DataAnalyticsAgent{
+			StagingContext: &AgentContext{
+				SystemInstruction: opts.Instructions,
+				DatasourceReferences: &DatasourceReferences{
+					BQ: &BigQueryTableReferences{
+						TableReferences: tableRefs,
+					},
+				},
+				ExampleQueries: opts.ExampleQueries,
+			},
+		},
+	}
+
+	body, err := json.Marshal(agentBody)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling create-agent request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	// dataAgentId is a query parameter, not in the body.
+	apiURL := fmt.Sprintf(dataAgentsBaseURL, projectID, location)
+	if opts.AgentID != "" {
+		apiURL += "?dataAgentId=" + opts.AgentID
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
@@ -290,28 +318,28 @@ func (c *Client) CreateAgent(ctx context.Context, token, projectID, location str
 		return nil, readAPIError(resp)
 	}
 
+	// Response is a long-running Operation.
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading create-agent response: %w", err)
 	}
 
-	var raw map[string]interface{}
-	if err := json.Unmarshal(respBody, &raw); err != nil {
+	var operation map[string]interface{}
+	if err := json.Unmarshal(respBody, &operation); err != nil {
 		return nil, fmt.Errorf("parsing create-agent response: %w", err)
 	}
 
-	name := ""
-	if n, ok := raw["name"].(string); ok {
-		name = n
-	}
+	opName, _ := operation["name"].(string)
 
 	return &CreateAgentResult{
-		Name:   name,
-		Status: "created",
+		OperationName: opName,
+		AgentID:       opts.AgentID,
+		Status:        "operation_started",
 	}, nil
 }
 
-// ListAgents lists data agents in the given project.
+// ListAgents lists data agents in the given project via the Data Agents v1alpha API.
+// Docs: https://docs.cloud.google.com/gemini/data-agents/reference/rest/v1alpha/projects.locations.dataAgents/list
 func (c *Client) ListAgents(ctx context.Context, token, projectID, location string) (*AgentsListResult, error) {
 	if projectID == "" {
 		return nil, fmt.Errorf("project ID is required")
@@ -320,9 +348,9 @@ func (c *Client) ListAgents(ctx context.Context, token, projectID, location stri
 		location = "us"
 	}
 
-	url := fmt.Sprintf(listAgentsURL, projectID, location)
+	apiURL := fmt.Sprintf(dataAgentsBaseURL, projectID, location)
 
-	httpReq, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
@@ -353,24 +381,7 @@ func (c *Client) ListAgents(ctx context.Context, token, projectID, location stri
 	if items, ok := raw["dataAgents"].([]interface{}); ok {
 		for _, item := range items {
 			if m, ok := item.(map[string]interface{}); ok {
-				agent := AgentSummary{}
-				if n, ok := m["name"].(string); ok {
-					agent.Name = n
-				}
-				if t, ok := m["createTime"].(string); ok {
-					agent.CreateTime = t
-				}
-				if tables, ok := m["tables"].([]interface{}); ok {
-					for _, t := range tables {
-						if s, ok := t.(string); ok {
-							agent.Tables = append(agent.Tables, s)
-						}
-					}
-				}
-				if vqs, ok := m["verifiedQueries"].([]interface{}); ok {
-					agent.VerifiedQueries = len(vqs)
-				}
-				agents = append(agents, agent)
+				agents = append(agents, parseAgentSummary(m))
 			}
 		}
 	}
@@ -385,8 +396,11 @@ func (c *Client) ListAgents(ctx context.Context, token, projectID, location stri
 	}, nil
 }
 
-// AddVerifiedQuery adds a verified query to an existing data agent.
-func (c *Client) AddVerifiedQuery(ctx context.Context, token, projectID, location string, req AddVerifiedQueryRequest) (*AddVerifiedQueryResult, error) {
+// AddVerifiedQuery adds example queries to an existing data agent via PATCH.
+// There is no standalone addVerifiedQuery method in the API; verified queries
+// (exampleQueries) are fields on the DataAgent resource updated via patch.
+// Docs: https://docs.cloud.google.com/gemini/data-agents/reference/rest/v1alpha/projects.locations.dataAgents
+func (c *Client) AddVerifiedQuery(ctx context.Context, token, projectID, location string, opts PatchAgentOpts) (*AddVerifiedQueryResult, error) {
 	if projectID == "" {
 		return nil, fmt.Errorf("project ID is required")
 	}
@@ -394,38 +408,118 @@ func (c *Client) AddVerifiedQuery(ctx context.Context, token, projectID, locatio
 		location = "us"
 	}
 
-	url := fmt.Sprintf(addVerifiedQueryURL, projectID, location, req.Agent)
+	// First GET the existing agent to read current exampleQueries.
+	agentResourceName := fmt.Sprintf("projects/%s/locations/%s/dataAgents/%s", projectID, location, opts.AgentName)
+	getURL := fmt.Sprintf(dataAgentURL, agentResourceName)
 
-	body, err := json.Marshal(map[string]interface{}{
-		"question": req.Question,
-		"query":    req.Query,
-	})
+	getReq, err := http.NewRequestWithContext(ctx, "GET", getURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("marshaling add-verified-query request: %w", err)
+		return nil, fmt.Errorf("creating get request: %w", err)
+	}
+	getReq.Header.Set("Authorization", "Bearer "+token)
+	getReq.Header.Set("Accept", "application/json")
+
+	getResp, err := c.HTTPClient.Do(getReq)
+	if err != nil {
+		return nil, fmt.Errorf("get agent failed: %w", err)
+	}
+	defer getResp.Body.Close()
+
+	if getResp.StatusCode >= 400 {
+		return nil, readAPIError(getResp)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	getBody, err := io.ReadAll(getResp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
+		return nil, fmt.Errorf("reading get response: %w", err)
 	}
-	httpReq.Header.Set("Authorization", "Bearer "+token)
-	httpReq.Header.Set("Content-Type", "application/json")
 
-	resp, err := c.HTTPClient.Do(httpReq)
+	var existing DataAgent
+	if err := json.Unmarshal(getBody, &existing); err != nil {
+		return nil, fmt.Errorf("parsing existing agent: %w", err)
+	}
+
+	// Append new example queries to staging context.
+	if existing.DataAnalyticsAgent == nil {
+		existing.DataAnalyticsAgent = &DataAnalyticsAgent{}
+	}
+	if existing.DataAnalyticsAgent.StagingContext == nil {
+		existing.DataAnalyticsAgent.StagingContext = &AgentContext{}
+	}
+	existing.DataAnalyticsAgent.StagingContext.ExampleQueries = append(
+		existing.DataAnalyticsAgent.StagingContext.ExampleQueries,
+		opts.ExampleQueries...,
+	)
+
+	// PATCH the agent with updated exampleQueries.
+	patchBody, err := json.Marshal(existing)
 	if err != nil {
-		return nil, fmt.Errorf("add-verified-query API request failed: %w", err)
+		return nil, fmt.Errorf("marshaling patch request: %w", err)
 	}
-	defer resp.Body.Close()
 
-	if resp.StatusCode >= 400 {
-		return nil, readAPIError(resp)
+	patchURL := fmt.Sprintf(dataAgentURL, agentResourceName) +
+		"?updateMask=dataAnalyticsAgent.stagingContext.exampleQueries"
+
+	patchReq, err := http.NewRequestWithContext(ctx, "PATCH", patchURL, bytes.NewReader(patchBody))
+	if err != nil {
+		return nil, fmt.Errorf("creating patch request: %w", err)
+	}
+	patchReq.Header.Set("Authorization", "Bearer "+token)
+	patchReq.Header.Set("Content-Type", "application/json")
+
+	patchResp, err := c.HTTPClient.Do(patchReq)
+	if err != nil {
+		return nil, fmt.Errorf("patch agent failed: %w", err)
+	}
+	defer patchResp.Body.Close()
+
+	if patchResp.StatusCode >= 400 {
+		return nil, readAPIError(patchResp)
 	}
 
 	return &AddVerifiedQueryResult{
-		Agent:    req.Agent,
-		Question: req.Question,
-		Status:   "added",
+		Agent:        opts.AgentName,
+		QueriesAdded: len(opts.ExampleQueries),
+		Status:       "added",
 	}, nil
+}
+
+// parseAgentSummary extracts a summary from a raw DataAgent JSON map.
+func parseAgentSummary(m map[string]interface{}) AgentSummary {
+	agent := AgentSummary{}
+	if n, ok := m["name"].(string); ok {
+		agent.Name = n
+	}
+	if d, ok := m["displayName"].(string); ok {
+		agent.DisplayName = d
+	}
+	if t, ok := m["createTime"].(string); ok {
+		agent.CreateTime = t
+	}
+	// Count exampleQueries from stagingContext.
+	if daa, ok := m["dataAnalyticsAgent"].(map[string]interface{}); ok {
+		for _, ctxKey := range []string{"stagingContext", "publishedContext"} {
+			if ctx, ok := daa[ctxKey].(map[string]interface{}); ok {
+				if eqs, ok := ctx["exampleQueries"].([]interface{}); ok {
+					agent.ExampleQueries = len(eqs)
+				}
+			}
+		}
+	}
+	return agent
+}
+
+// parseBQTableRef parses "project.dataset.table" into a BigQueryTableReference.
+func parseBQTableRef(ref string) BigQueryTableReference {
+	parts := strings.SplitN(ref, ".", 3)
+	switch len(parts) {
+	case 3:
+		return BigQueryTableReference{ProjectID: parts[0], DatasetID: parts[1], TableID: parts[2]}
+	case 2:
+		return BigQueryTableReference{DatasetID: parts[0], TableID: parts[1]}
+	default:
+		return BigQueryTableReference{TableID: ref}
+	}
 }
 
 func readAPIError(resp *http.Response) error {

--- a/internal/ca/client_test.go
+++ b/internal/ca/client_test.go
@@ -1,6 +1,7 @@
 package ca
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/haiyuan-eng-google/dcx-cli/internal/profiles"
@@ -29,6 +30,77 @@ func TestNewClient(t *testing.T) {
 	c := NewClient(nil)
 	if c.HTTPClient == nil {
 		t.Error("NewClient(nil) should set default HTTP client")
+	}
+}
+
+func TestParseBQTableRef(t *testing.T) {
+	tests := []struct {
+		input string
+		want  BigQueryTableReference
+	}{
+		{"proj.ds.tbl", BigQueryTableReference{ProjectID: "proj", DatasetID: "ds", TableID: "tbl"}},
+		{"ds.tbl", BigQueryTableReference{DatasetID: "ds", TableID: "tbl"}},
+		{"tbl", BigQueryTableReference{TableID: "tbl"}},
+	}
+	for _, tt := range tests {
+		got := parseBQTableRef(tt.input)
+		if got != tt.want {
+			t.Errorf("parseBQTableRef(%q) = %+v, want %+v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestDataAgentJSONShape(t *testing.T) {
+	// Verify the DataAgent struct produces the documented API shape.
+	agent := DataAgent{
+		DisplayName: "test-agent",
+		DataAnalyticsAgent: &DataAnalyticsAgent{
+			StagingContext: &AgentContext{
+				SystemInstruction: "You help analyze data.",
+				DatasourceReferences: &DatasourceReferences{
+					BQ: &BigQueryTableReferences{
+						TableReferences: []BigQueryTableReference{
+							{ProjectID: "proj", DatasetID: "ds", TableID: "events"},
+						},
+					},
+				},
+				ExampleQueries: []ExampleQuery{
+					{NaturalLanguageQuestion: "How many events?", SQLQuery: "SELECT COUNT(*) FROM events"},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(agent)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var raw map[string]interface{}
+	json.Unmarshal(data, &raw)
+
+	// Verify nested structure matches documented API.
+	daa, ok := raw["dataAnalyticsAgent"].(map[string]interface{})
+	if !ok {
+		t.Fatal("missing dataAnalyticsAgent")
+	}
+	sc, ok := daa["stagingContext"].(map[string]interface{})
+	if !ok {
+		t.Fatal("missing stagingContext")
+	}
+	if sc["systemInstruction"] != "You help analyze data." {
+		t.Errorf("systemInstruction = %v", sc["systemInstruction"])
+	}
+	eqs, ok := sc["exampleQueries"].([]interface{})
+	if !ok || len(eqs) != 1 {
+		t.Fatalf("exampleQueries should have 1 entry, got %v", sc["exampleQueries"])
+	}
+	eq := eqs[0].(map[string]interface{})
+	if eq["naturalLanguageQuestion"] != "How many events?" {
+		t.Errorf("naturalLanguageQuestion = %v", eq["naturalLanguageQuestion"])
+	}
+	if eq["sqlQuery"] != "SELECT COUNT(*) FROM events" {
+		t.Errorf("sqlQuery = %v", eq["sqlQuery"])
 	}
 }
 

--- a/internal/ca/models.go
+++ b/internal/ca/models.go
@@ -44,6 +44,56 @@ type QueryDataResponse struct {
 	SourceType  string      `json:"source_type"`
 }
 
+// VerifiedQuery is a pre-authored question/SQL pair that improves agent accuracy.
+type VerifiedQuery struct {
+	Question string `json:"question" yaml:"question"`
+	Query    string `json:"query" yaml:"query"`
+}
+
+// CreateAgentRequest is the request body for creating a data agent.
+type CreateAgentRequest struct {
+	Name             string          `json:"name"`
+	Tables           []string        `json:"tables"`
+	Views            []string        `json:"views,omitempty"`
+	VerifiedQueries  []VerifiedQuery `json:"verified_queries,omitempty"`
+	Instructions     string          `json:"instructions,omitempty"`
+}
+
+// AgentSummary is the compact representation for list-agents output.
+type AgentSummary struct {
+	Name            string   `json:"name"`
+	Tables          []string `json:"tables,omitempty"`
+	VerifiedQueries int      `json:"verified_queries_count,omitempty"`
+	CreateTime      string   `json:"create_time,omitempty"`
+}
+
+// AgentsListResult is the output of ca list-agents.
+type AgentsListResult struct {
+	Items  []AgentSummary `json:"items"`
+	Source string         `json:"source"`
+}
+
+// CreateAgentResult is the output of ca create-agent.
+type CreateAgentResult struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+}
+
+// AddVerifiedQueryRequest is the request body for adding a verified query.
+type AddVerifiedQueryRequest struct {
+	Agent    string `json:"agent"`
+	Question string `json:"question"`
+	Query    string `json:"query"`
+}
+
+// AddVerifiedQueryResult is the output of ca add-verified-query.
+type AddVerifiedQueryResult struct {
+	Agent    string `json:"agent"`
+	Question string `json:"question"`
+	Status   string `json:"status"`
+}
+
 // AskResult is the unified output for ca ask across all source types.
 type AskResult struct {
 	Question    string      `json:"question"`

--- a/internal/ca/models.go
+++ b/internal/ca/models.go
@@ -44,27 +44,74 @@ type QueryDataResponse struct {
 	SourceType  string      `json:"source_type"`
 }
 
-// VerifiedQuery is a pre-authored question/SQL pair that improves agent accuracy.
-type VerifiedQuery struct {
-	Question string `json:"question" yaml:"question"`
-	Query    string `json:"query" yaml:"query"`
+// ExampleQuery is a verified question/SQL pair (called "exampleQueries"
+// in the Data Agents API) that improves agent accuracy.
+// YAML tag supports the user-facing "verified_queries" naming in YAML files.
+type ExampleQuery struct {
+	NaturalLanguageQuestion string `json:"naturalLanguageQuestion" yaml:"question"`
+	SQLQuery                string `json:"sqlQuery" yaml:"query"`
 }
 
-// CreateAgentRequest is the request body for creating a data agent.
-type CreateAgentRequest struct {
-	Name             string          `json:"name"`
-	Tables           []string        `json:"tables"`
-	Views            []string        `json:"views,omitempty"`
-	VerifiedQueries  []VerifiedQuery `json:"verified_queries,omitempty"`
-	Instructions     string          `json:"instructions,omitempty"`
+// BigQueryTableReference identifies a BigQuery table for agent context.
+type BigQueryTableReference struct {
+	ProjectID string `json:"projectId"`
+	DatasetID string `json:"datasetId"`
+	TableID   string `json:"tableId"`
 }
 
-// AgentSummary is the compact representation for list-agents output.
+// BigQueryTableReferences wraps table references for the datasource field.
+type BigQueryTableReferences struct {
+	TableReferences []BigQueryTableReference `json:"tableReferences"`
+}
+
+// DatasourceReferences is a union type; BigQuery is the only variant
+// supported for create-agent.
+type DatasourceReferences struct {
+	BQ *BigQueryTableReferences `json:"bq,omitempty"`
+}
+
+// AgentContext holds the data context for a DataAnalyticsAgent.
+// This maps to stagingContext / publishedContext in the API.
+type AgentContext struct {
+	SystemInstruction    string                `json:"systemInstruction,omitempty"`
+	DatasourceReferences *DatasourceReferences `json:"datasourceReferences,omitempty"`
+	ExampleQueries       []ExampleQuery        `json:"exampleQueries,omitempty"`
+}
+
+// DataAnalyticsAgent is the typed agent payload nested inside DataAgent.
+type DataAnalyticsAgent struct {
+	StagingContext   *AgentContext `json:"stagingContext,omitempty"`
+	PublishedContext *AgentContext `json:"publishedContext,omitempty"`
+}
+
+// DataAgent is the top-level resource for the Data Agents management API.
+// Docs: https://docs.cloud.google.com/gemini/data-agents/reference/rest/v1alpha/projects.locations.dataAgents
+type DataAgent struct {
+	Name               string              `json:"name,omitempty"`
+	DisplayName        string              `json:"displayName,omitempty"`
+	Description        string              `json:"description,omitempty"`
+	DataAnalyticsAgent *DataAnalyticsAgent  `json:"dataAnalyticsAgent,omitempty"`
+	CreateTime         string              `json:"createTime,omitempty"`
+	UpdateTime         string              `json:"updateTime,omitempty"`
+}
+
+// CreateAgentOpts holds the user-facing options for ca create-agent.
+// These are mapped into the DataAgent API shape by the client.
+type CreateAgentOpts struct {
+	AgentID      string         // passed as ?dataAgentId= query param
+	DisplayName  string
+	Tables       []string       // "project.dataset.table" refs
+	Views        []string       // additional view refs (also as table refs)
+	ExampleQueries []ExampleQuery
+	Instructions string
+}
+
+// AgentSummary is the dcx output representation for a single agent.
 type AgentSummary struct {
-	Name            string   `json:"name"`
-	Tables          []string `json:"tables,omitempty"`
-	VerifiedQueries int      `json:"verified_queries_count,omitempty"`
-	CreateTime      string   `json:"create_time,omitempty"`
+	Name            string `json:"name"`
+	DisplayName     string `json:"display_name,omitempty"`
+	ExampleQueries  int    `json:"example_queries_count,omitempty"`
+	CreateTime      string `json:"create_time,omitempty"`
 }
 
 // AgentsListResult is the output of ca list-agents.
@@ -74,24 +121,25 @@ type AgentsListResult struct {
 }
 
 // CreateAgentResult is the output of ca create-agent.
+// The API returns a long-running Operation; we surface the operation name
+// and the agent name from the metadata.
 type CreateAgentResult struct {
-	Name    string `json:"name"`
-	Status  string `json:"status"`
-	Message string `json:"message,omitempty"`
+	OperationName string `json:"operation_name"`
+	AgentID       string `json:"agent_id"`
+	Status        string `json:"status"`
 }
 
-// AddVerifiedQueryRequest is the request body for adding a verified query.
-type AddVerifiedQueryRequest struct {
-	Agent    string `json:"agent"`
-	Question string `json:"question"`
-	Query    string `json:"query"`
+// PatchAgentOpts holds options for patching an agent (used by add-verified-query).
+type PatchAgentOpts struct {
+	AgentName      string         // full resource name
+	ExampleQueries []ExampleQuery // queries to add
 }
 
 // AddVerifiedQueryResult is the output of ca add-verified-query.
 type AddVerifiedQueryResult struct {
-	Agent    string `json:"agent"`
-	Question string `json:"question"`
-	Status   string `json:"status"`
+	Agent         string `json:"agent"`
+	QueriesAdded  int    `json:"queries_added"`
+	Status        string `json:"status"`
 }
 
 // AskResult is the unified output for ca ask across all source types.

--- a/internal/ca/models.go
+++ b/internal/ca/models.go
@@ -98,13 +98,11 @@ type PatchAgentOpts struct {
 }
 
 // AddVerifiedQueryResult is the output of ca add-verified-query.
-// The PATCH API returns a long-running Operation; status reflects
-// whether the operation completed synchronously or is still running.
 type AddVerifiedQueryResult struct {
-	Agent         string `json:"agent"`
-	QueriesAdded  int    `json:"queries_added"`
-	OperationName string `json:"operation_name,omitempty"`
-	Status        string `json:"status"`
+	Agent                string `json:"agent"`
+	QueriesAdded         int    `json:"queries_added"`
+	TotalVerifiedQueries int    `json:"total_verified_queries"`
+	Status               string `json:"status"`
 }
 
 // AskResult is the unified output for ca ask across all source types.

--- a/internal/ca/models.go
+++ b/internal/ca/models.go
@@ -6,44 +6,6 @@
 //     queries through the QueryData endpoint
 package ca
 
-// ChatRequest is the request body for the CA Chat API (DataAgent).
-type ChatRequest struct {
-	Question string `json:"question"`
-	Agent    string `json:"agent,omitempty"`
-	Tables   string `json:"tables,omitempty"`
-}
-
-// ChatResponse is the response from the CA Chat API.
-type ChatResponse struct {
-	Question    string      `json:"question"`
-	SQL         string      `json:"sql,omitempty"`
-	Results     interface{} `json:"results,omitempty"`
-	Explanation string      `json:"explanation,omitempty"`
-	Agent       string      `json:"agent,omitempty"`
-}
-
-// QueryDataRequest is the request body for the CA QueryData API.
-type QueryDataRequest struct {
-	Question              string `json:"question"`
-	ProjectID             string `json:"project_id"`
-	SourceType            string `json:"source_type"`
-	Location              string `json:"location,omitempty"`
-	InstanceID            string `json:"instance_id,omitempty"`
-	DatabaseID            string `json:"database_id,omitempty"`
-	ClusterID             string `json:"cluster_id,omitempty"`
-	DBType                string `json:"db_type,omitempty"`
-	AgentContextReference string `json:"agent_context_reference,omitempty"`
-}
-
-// QueryDataResponse is the response from the CA QueryData API.
-type QueryDataResponse struct {
-	Question    string      `json:"question"`
-	SQL         string      `json:"sql,omitempty"`
-	Results     interface{} `json:"results,omitempty"`
-	Explanation string      `json:"explanation,omitempty"`
-	SourceType  string      `json:"source_type"`
-}
-
 // ExampleQuery is a verified question/SQL pair (called "exampleQueries"
 // in the Data Agents API) that improves agent accuracy.
 // YAML tag supports the user-facing "verified_queries" naming in YAML files.

--- a/internal/ca/models.go
+++ b/internal/ca/models.go
@@ -136,9 +136,12 @@ type PatchAgentOpts struct {
 }
 
 // AddVerifiedQueryResult is the output of ca add-verified-query.
+// The PATCH API returns a long-running Operation; status reflects
+// whether the operation completed synchronously or is still running.
 type AddVerifiedQueryResult struct {
 	Agent         string `json:"agent"`
 	QueriesAdded  int    `json:"queries_added"`
+	OperationName string `json:"operation_name,omitempty"`
 	Status        string `json:"status"`
 }
 

--- a/internal/cli/ca.go
+++ b/internal/cli/ca.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/haiyuan-eng-google/dcx-cli/internal/auth"
@@ -12,6 +13,7 @@ import (
 	"github.com/haiyuan-eng-google/dcx-cli/internal/output"
 	"github.com/haiyuan-eng-google/dcx-cli/internal/profiles"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func (a *App) addCACommands() {
@@ -21,6 +23,9 @@ func (a *App) addCACommands() {
 	}
 
 	caCmd.AddCommand(a.caAskCmd())
+	caCmd.AddCommand(a.caCreateAgentCmd())
+	caCmd.AddCommand(a.caListAgentsCmd())
+	caCmd.AddCommand(a.caAddVerifiedQueryCmd())
 	a.Root.AddCommand(caCmd)
 
 	a.Registry.Register(contracts.BuildContract(
@@ -33,6 +38,33 @@ func (a *App) addCACommands() {
 			{Name: "tables", Type: "string", Description: "Comma-separated table refs (BigQuery)"},
 		},
 		false, false,
+	))
+	a.Registry.Register(contracts.BuildContract(
+		"ca create-agent", "ca",
+		"Create a BigQuery data agent with table refs and optional verified queries",
+		[]contracts.FlagContract{
+			{Name: "name", Type: "string", Description: "Agent name (alphanumeric, hyphens, underscores, dots)", Required: true},
+			{Name: "tables", Type: "string", Description: "Comma-separated fully qualified table refs", Required: true},
+			{Name: "views", Type: "string", Description: "Comma-separated view refs as additional data sources"},
+			{Name: "verified-queries", Type: "string", Description: "Path to verified queries YAML file"},
+			{Name: "instructions", Type: "string", Description: "System instructions for the agent"},
+		},
+		true, false,
+	))
+	a.Registry.Register(contracts.BuildContract(
+		"ca list-agents", "ca",
+		"List data agents in the current project",
+		nil, false, false,
+	))
+	a.Registry.Register(contracts.BuildContract(
+		"ca add-verified-query", "ca",
+		"Add a verified query to an existing data agent",
+		[]contracts.FlagContract{
+			{Name: "agent", Type: "string", Description: "Data agent name", Required: true},
+			{Name: "question", Type: "string", Description: "Natural language question", Required: true},
+			{Name: "query", Type: "string", Description: "SQL query", Required: true},
+		},
+		true, false,
 	))
 }
 
@@ -106,4 +138,217 @@ func (a *App) caAskCmd() *cobra.Command {
 	cmd.Flags().StringVar(&tables, "tables", "", "Comma-separated table refs (BigQuery)")
 
 	return cmd
+}
+
+func (a *App) caCreateAgentCmd() *cobra.Command {
+	var name, tables, views, verifiedQueriesPath, instructions string
+
+	cmd := &cobra.Command{
+		Use:   "create-agent",
+		Short: "Create a BigQuery data agent with table refs and optional verified queries",
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			if name == "" {
+				dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --name is missing", "")
+				return nil
+			}
+			if tables == "" {
+				dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --tables is missing", "")
+				return nil
+			}
+
+			format, err := a.OutputFormat()
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.InvalidConfig, err.Error(), "")
+				return nil
+			}
+
+			ctx := context.Background()
+			resolved, err := auth.Resolve(ctx, a.AuthConfig())
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.AuthError, err.Error(), "")
+				return nil
+			}
+			tok, err := resolved.TokenSource.Token()
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.AuthError, fmt.Sprintf("failed to obtain token: %v", err), "")
+				return nil
+			}
+
+			projectID := a.Opts.ProjectID
+			if projectID == "" {
+				dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --project-id is missing", "")
+				return nil
+			}
+
+			req := ca.CreateAgentRequest{
+				Name:         name,
+				Tables:       splitCSV(tables),
+				Instructions: instructions,
+			}
+			if views != "" {
+				req.Views = splitCSV(views)
+			}
+			if verifiedQueriesPath != "" {
+				vqs, err := loadVerifiedQueries(verifiedQueriesPath)
+				if err != nil {
+					dcxerrors.Emit(dcxerrors.InvalidConfig, fmt.Sprintf("loading verified queries: %v", err), "")
+					return nil
+				}
+				req.VerifiedQueries = vqs
+			}
+
+			client := ca.NewClient(nil)
+			result, err := client.CreateAgent(ctx, tok.AccessToken, projectID, a.Opts.Location, req)
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.APIError, err.Error(), "")
+				return nil
+			}
+
+			return output.Render(format, result)
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Agent name (required)")
+	cmd.Flags().StringVar(&tables, "tables", "", "Comma-separated fully qualified table refs (required)")
+	cmd.Flags().StringVar(&views, "views", "", "Comma-separated view refs")
+	cmd.Flags().StringVar(&verifiedQueriesPath, "verified-queries", "", "Path to verified queries YAML file")
+	cmd.Flags().StringVar(&instructions, "instructions", "", "System instructions for the agent")
+
+	return cmd
+}
+
+func (a *App) caListAgentsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list-agents",
+		Short: "List data agents in the current project",
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			format, err := a.OutputFormat()
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.InvalidConfig, err.Error(), "")
+				return nil
+			}
+
+			ctx := context.Background()
+			resolved, err := auth.Resolve(ctx, a.AuthConfig())
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.AuthError, err.Error(), "")
+				return nil
+			}
+			tok, err := resolved.TokenSource.Token()
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.AuthError, fmt.Sprintf("failed to obtain token: %v", err), "")
+				return nil
+			}
+
+			projectID := a.Opts.ProjectID
+			if projectID == "" {
+				dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --project-id is missing", "")
+				return nil
+			}
+
+			client := ca.NewClient(nil)
+			result, err := client.ListAgents(ctx, tok.AccessToken, projectID, a.Opts.Location)
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.APIError, err.Error(), "")
+				return nil
+			}
+
+			return output.Render(format, result)
+		},
+	}
+}
+
+func (a *App) caAddVerifiedQueryCmd() *cobra.Command {
+	var agentName, question, query string
+
+	cmd := &cobra.Command{
+		Use:   "add-verified-query",
+		Short: "Add a verified query to an existing data agent",
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			if agentName == "" {
+				dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --agent is missing", "")
+				return nil
+			}
+			if question == "" {
+				dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --question is missing", "")
+				return nil
+			}
+			if query == "" {
+				dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --query is missing", "")
+				return nil
+			}
+
+			format, err := a.OutputFormat()
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.InvalidConfig, err.Error(), "")
+				return nil
+			}
+
+			ctx := context.Background()
+			resolved, err := auth.Resolve(ctx, a.AuthConfig())
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.AuthError, err.Error(), "")
+				return nil
+			}
+			tok, err := resolved.TokenSource.Token()
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.AuthError, fmt.Sprintf("failed to obtain token: %v", err), "")
+				return nil
+			}
+
+			projectID := a.Opts.ProjectID
+			if projectID == "" {
+				dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --project-id is missing", "")
+				return nil
+			}
+
+			client := ca.NewClient(nil)
+			result, err := client.AddVerifiedQuery(ctx, tok.AccessToken, projectID, a.Opts.Location, ca.AddVerifiedQueryRequest{
+				Agent:    agentName,
+				Question: question,
+				Query:    query,
+			})
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.APIError, err.Error(), "")
+				return nil
+			}
+
+			return output.Render(format, result)
+		},
+	}
+
+	cmd.Flags().StringVar(&agentName, "agent", "", "Data agent name (required)")
+	cmd.Flags().StringVar(&question, "question", "", "Natural language question (required)")
+	cmd.Flags().StringVar(&query, "query", "", "SQL query (required)")
+
+	return cmd
+}
+
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	var result []string
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+// loadVerifiedQueries reads a YAML file containing verified queries.
+func loadVerifiedQueries(path string) ([]ca.VerifiedQuery, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	var doc struct {
+		VerifiedQueries []ca.VerifiedQuery `yaml:"verified_queries"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	return doc.VerifiedQueries, nil
 }

--- a/internal/cli/ca.go
+++ b/internal/cli/ca.go
@@ -180,25 +180,26 @@ func (a *App) caCreateAgentCmd() *cobra.Command {
 				return nil
 			}
 
-			req := ca.CreateAgentRequest{
-				Name:         name,
+			opts := ca.CreateAgentOpts{
+				AgentID:      name,
+				DisplayName:  name,
 				Tables:       splitCSV(tables),
 				Instructions: instructions,
 			}
 			if views != "" {
-				req.Views = splitCSV(views)
+				opts.Views = splitCSV(views)
 			}
 			if verifiedQueriesPath != "" {
-				vqs, err := loadVerifiedQueries(verifiedQueriesPath)
+				eqs, err := loadExampleQueries(verifiedQueriesPath)
 				if err != nil {
 					dcxerrors.Emit(dcxerrors.InvalidConfig, fmt.Sprintf("loading verified queries: %v", err), "")
 					return nil
 				}
-				req.VerifiedQueries = vqs
+				opts.ExampleQueries = eqs
 			}
 
 			client := ca.NewClient(nil)
-			result, err := client.CreateAgent(ctx, tok.AccessToken, projectID, a.Opts.Location, req)
+			result, err := client.CreateAgent(ctx, tok.AccessToken, projectID, a.Opts.Location, opts)
 			if err != nil {
 				dcxerrors.Emit(dcxerrors.APIError, err.Error(), "")
 				return nil
@@ -303,10 +304,11 @@ func (a *App) caAddVerifiedQueryCmd() *cobra.Command {
 			}
 
 			client := ca.NewClient(nil)
-			result, err := client.AddVerifiedQuery(ctx, tok.AccessToken, projectID, a.Opts.Location, ca.AddVerifiedQueryRequest{
-				Agent:    agentName,
-				Question: question,
-				Query:    query,
+			result, err := client.AddVerifiedQuery(ctx, tok.AccessToken, projectID, a.Opts.Location, ca.PatchAgentOpts{
+				AgentName: agentName,
+				ExampleQueries: []ca.ExampleQuery{
+					{NaturalLanguageQuestion: question, SQLQuery: query},
+				},
 			})
 			if err != nil {
 				dcxerrors.Emit(dcxerrors.APIError, err.Error(), "")
@@ -336,15 +338,17 @@ func splitCSV(s string) []string {
 	return result
 }
 
-// loadVerifiedQueries reads a YAML file containing verified queries.
-func loadVerifiedQueries(path string) ([]ca.VerifiedQuery, error) {
+// loadExampleQueries reads a YAML file containing verified queries.
+// The YAML uses the user-facing "verified_queries" key with "question"
+// and "query" fields, which map to ExampleQuery's YAML tags.
+func loadExampleQueries(path string) ([]ca.ExampleQuery, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", path, err)
 	}
 
 	var doc struct {
-		VerifiedQueries []ca.VerifiedQuery `yaml:"verified_queries"`
+		VerifiedQueries []ca.ExampleQuery `yaml:"verified_queries"`
 	}
 	if err := yaml.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", path, err)

--- a/internal/cli/ca.go
+++ b/internal/cli/ca.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/haiyuan-eng-google/dcx-cli/internal/auth"
@@ -43,7 +44,7 @@ func (a *App) addCACommands() {
 		"ca create-agent", "ca",
 		"Create a BigQuery data agent with table refs and optional verified queries",
 		[]contracts.FlagContract{
-			{Name: "name", Type: "string", Description: "Agent name (alphanumeric, hyphens, underscores, dots)", Required: true},
+			{Name: "name", Type: "string", Description: "Agent ID: lowercase letters, digits, hyphens; must start with a letter (regex: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$)", Required: true},
 			{Name: "tables", Type: "string", Description: "Comma-separated fully qualified table refs", Required: true},
 			{Name: "views", Type: "string", Description: "Comma-separated view refs as additional data sources"},
 			{Name: "verified-queries", Type: "string", Description: "Path to verified queries YAML file"},
@@ -151,6 +152,12 @@ func (a *App) caCreateAgentCmd() *cobra.Command {
 				dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --name is missing", "")
 				return nil
 			}
+			if !isValidAgentID(name) {
+				dcxerrors.Emit(dcxerrors.InvalidIdentifier,
+					fmt.Sprintf("invalid agent ID %q: must match ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$", name),
+					"Use lowercase letters, digits, and hyphens; must start with a letter")
+				return nil
+			}
 			if tables == "" {
 				dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --tables is missing", "")
 				return nil
@@ -209,7 +216,7 @@ func (a *App) caCreateAgentCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&name, "name", "", "Agent name (required)")
+	cmd.Flags().StringVar(&name, "name", "", "Agent ID: lowercase, digits, hyphens; starts with letter (required)")
 	cmd.Flags().StringVar(&tables, "tables", "", "Comma-separated fully qualified table refs (required)")
 	cmd.Flags().StringVar(&views, "views", "", "Comma-separated view refs")
 	cmd.Flags().StringVar(&verifiedQueriesPath, "verified-queries", "", "Path to verified queries YAML file")
@@ -355,4 +362,12 @@ func loadExampleQueries(path string) ([]ca.ExampleQuery, error) {
 	}
 
 	return doc.VerifiedQueries, nil
+}
+
+// agentIDPattern matches the documented dataAgentId format.
+var agentIDPattern = regexp.MustCompile(`^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$`)
+
+// isValidAgentID checks if an agent ID matches the API-documented format.
+func isValidAgentID(id string) bool {
+	return agentIDPattern.MatchString(id)
 }

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -110,6 +110,7 @@ func TestCommandDiscovery(t *testing.T) {
 		"dcx looker explores list", "dcx looker dashboards get",
 		// CA
 		"dcx ca ask",
+		"dcx ca create-agent", "dcx ca list-agents", "dcx ca add-verified-query",
 		// Auth
 		"dcx auth check", "dcx auth status",
 		// Profiles
@@ -131,8 +132,8 @@ func TestCommandDiscovery(t *testing.T) {
 		}
 	}
 
-	if len(commands) < 35 {
-		t.Errorf("expected at least 35 commands, got %d", len(commands))
+	if len(commands) < 38 {
+		t.Errorf("expected at least 38 commands, got %d", len(commands))
 	}
 }
 
@@ -421,9 +422,6 @@ func TestSkillAlignment(t *testing.T) {
 	p1Commands := map[string]bool{
 		"dcx auth login":              true,
 		"dcx auth logout":             true,
-		"dcx ca create-agent":         true,
-		"dcx ca list-agents":          true,
-		"dcx ca add-verified-query":   true,
 		"dcx looker explores get":     true,
 		"dcx looker dashboards list":  true,
 		"dcx generate-skills":         true,

--- a/skills/dcx-ca/references/create-agent.md
+++ b/skills/dcx-ca/references/create-agent.md
@@ -18,7 +18,7 @@ dcx ca create-agent \
 | `--name` | Yes | Agent ID: lowercase letters, digits, hyphens; must start with a letter (`^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$`) |
 | `--tables` | Yes | Comma-separated fully qualified table refs |
 | `--views` | No | Comma-separated view refs as additional data sources |
-| `--verified-queries` | No | Path to verified queries YAML (defaults to bundled) |
+| `--verified-queries` | No | Path to verified queries YAML file |
 | `--instructions` | No | System instructions for the agent |
 
 ## Verified queries format

--- a/skills/dcx-ca/references/create-agent.md
+++ b/skills/dcx-ca/references/create-agent.md
@@ -15,7 +15,7 @@ dcx ca create-agent \
 
 | Flag | Required | Description |
 |------|----------|-------------|
-| `--name` | Yes | Agent ID (alphanumeric, hyphens, underscores, dots) |
+| `--name` | Yes | Agent ID: lowercase letters, digits, hyphens; must start with a letter (`^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$`) |
 | `--tables` | Yes | Comma-separated fully qualified table refs |
 | `--views` | No | Comma-separated view refs as additional data sources |
 | `--verified-queries` | No | Path to verified queries YAML (defaults to bundled) |


### PR DESCRIPTION
## Summary

Implements the three CA agent management commands that were deferred from the MVP (previously P1):

- **`ca create-agent`**: Create a BigQuery data agent with `--name`, `--tables` (required), `--views`, `--verified-queries` (YAML file), `--instructions`. Mutation command (`is_mutation: true`).
- **`ca list-agents`**: List data agents in the project. Returns `items` array with name, tables, verified query count, create time.
- **`ca add-verified-query`**: Add a verified question/SQL pair to an existing agent with `--agent`, `--question`, `--query` (all required).

### API surface

| Endpoint | Method | Command |
|----------|--------|---------|
| `dataAgents` | POST | `ca create-agent` |
| `dataAgents` | GET | `ca list-agents` |
| `dataAgents/{name}:addVerifiedQuery` | POST | `ca add-verified-query` |

### Changes

- `internal/ca/models.go`: Added VerifiedQuery, CreateAgentRequest, AgentSummary, AgentsListResult, CreateAgentResult, AddVerifiedQueryRequest/Result
- `internal/ca/client.go`: Added CreateAgent, ListAgents, AddVerifiedQuery methods + API endpoint constants
- `internal/cli/ca.go`: Added three cobra commands with flag parsing, verified-queries YAML loading
- `internal/eval/eval_test.go`: Updated to expect 38 commands; CA agent commands removed from P1 deferred list

**38 commands total** (was 35).

## Test plan

- [ ] `go test ./...` — all tests pass including updated eval suite
- [ ] `dcx ca create-agent --help` — shows --name, --tables, --views, --verified-queries, --instructions
- [ ] `dcx ca list-agents --help` — exists
- [ ] `dcx ca add-verified-query --help` — shows --agent, --question, --query
- [ ] `dcx meta commands` — lists all 38 commands including 4 CA commands
- [ ] `dcx meta describe ca create-agent` — contract shows `is_mutation: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)