### PR TITLE
Update docs for shipped CA agent management

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An agent-native CLI for Google Cloud's Data Cloud, built in Go.
 One binary for BigQuery, Spanner, AlloyDB, Cloud SQL, and Looker —
 with structured output, typed errors, and an MCP bridge for AI agents.
 
-> **Status:** Go MVP functional — 35 commands across 10 domains.
+> **Status:** Go MVP functional — 38 commands across 10 domains.
 > Benchmarked at **5x faster** than `bq` with token cost within 6%.
 > See [docs/benchmark_results_bigquery.md](docs/benchmark_results_bigquery.md)
 > for measured results.
@@ -43,11 +43,15 @@ dcx meta describe jobs query
 # Natural-language query via CA
 dcx ca ask "top errors yesterday" --profile my-spanner-profile
 
+# Create a data agent and ask it questions
+dcx ca create-agent --name=sales-agent --tables=myproject.sales.orders --project-id=myproject
+dcx ca ask "revenue by region this quarter" --agent=sales-agent --project-id=myproject
+
 # Start MCP server for agents
 dcx mcp serve
 ```
 
-## Commands (35 total)
+## Commands (38 total)
 
 | Surface | Commands |
 |---|---|
@@ -56,7 +60,7 @@ dcx mcp serve
 | **AlloyDB** | `clusters list/get`, `instances list/get`, `databases list`, `schema describe` |
 | **Cloud SQL** | `instances list/get`, `databases list/get`, `schema describe` |
 | **Looker** | `instances list/get`, `explores list`, `dashboards get` |
-| **CA** | `ca ask --profile ...` (natural-language queries across all sources) |
+| **CA** | `ca ask`, `ca create-agent`, `ca list-agents`, `ca add-verified-query` |
 | **Auth** | `auth status`, `auth check` |
 | **Profiles** | `profiles list`, `profiles validate`, `profiles test` |
 | **Introspection** | `meta commands`, `meta describe` |
@@ -68,7 +72,6 @@ Run `dcx meta commands` for the full machine-readable list.
 ### Deferred to P1
 
 - Agent Analytics SDK (12 commands, 6 evaluators)
-- CA agent management (`create-agent`, `list-agents`, `add-verified-query`)
 - `generate-skills`, Gemini manifest, shell completions
 - Model Armor sanitization
 
@@ -203,7 +206,7 @@ internal/
   auth/                         # 5-tier resolver
   discovery/                    # Discovery Document parser, command generation
   bigquery/                     # jobs query (static), BQ client
-  ca/                           # CA client (Chat + QueryData)
+  ca/                           # CA client (Chat + QueryData + Agent management)
   datacloud/                    # database helpers (schema describe)
   looker/                       # Looker Admin SDK client
   mcp/                          # MCP server (JSON-RPC 2.0 / stdio)

--- a/docs/go_mvp_plan.md
+++ b/docs/go_mvp_plan.md
@@ -145,8 +145,9 @@ deferred.
 For MVP, prioritize the profile-driven path over inline BigQuery-only agent
 management flows.
 
-`ca create-agent`, `ca list-agents`, and `ca add-verified-query` move to P1
-unless beta users show they are required for first-run value.
+`ca create-agent`, `ca list-agents`, and `ca add-verified-query` — **shipped**
+(merged in PR #7). Agent management uses `locations/global`; the `--location`
+flag is ignored for these commands.
 
 ### P0: Auth and profiles
 
@@ -210,7 +211,7 @@ CLI can continue serving this surface during the Go migration.
 - `generate-skills`
 - Gemini manifest generation (`meta gemini-tools`)
 - shell completions
-- `ca create-agent`, `ca list-agents`, `ca add-verified-query`
+- ~~`ca create-agent`, `ca list-agents`, `ca add-verified-query`~~ — **shipped** (PR #7)
 - Model Armor sanitization (`--sanitize`)
 
 ## Why this MVP, specifically
@@ -252,7 +253,7 @@ Key modules and estimated porting effort:
 | Skill templates | ~450 | `skills/` | `internal/skills/` |
 | **Total P0 source** | **~14,600** | | |
 | Analytics (P1) | ~4,170 | `commands/analytics/` | deferred |
-| CA management (P1) | ~400 | `commands/ca/` (3 cmds) | deferred |
+| CA management | ~400 | `commands/ca/` (3 cmds) | `internal/ca/` + `internal/cli/ca.go` — **shipped** |
 | Tests | ~8,000+ | `tests/` | `*_test.go` alongside packages |
 | Snapshot golden files | ~50 files | `tests/snapshots/` | `testdata/` |
 

--- a/docs/go_mvp_plan.md
+++ b/docs/go_mvp_plan.md
@@ -717,7 +717,7 @@ The right message is:
 
 ## Implementation status
 
-All 6 phases are complete. The Go MVP is functional with 35 commands
+All 6 phases are complete. The Go MVP is functional with 38 commands
 across 10 domains, benchmarked at 5x faster than `bq`.
 
 | Phase | Status | PR |

--- a/skills/dcx-ca/SKILL.md
+++ b/skills/dcx-ca/SKILL.md
@@ -16,7 +16,9 @@ Use when the user wants to:
 
 - BigQuery: `--project-id` (or `DCX_PROJECT`)
 - All other sources: `--profile` (YAML file defining source connection)
-- CA uses `--location` (defaults to `US`) but does **not** require `--dataset-id`
+- `ca ask` uses `--location` (defaults to `US`) for chat/queryData endpoints
+- Agent management (`create-agent`, `list-agents`, `add-verified-query`) always uses `locations/global` — the `--location` flag is ignored for these commands
+- Does **not** require `--dataset-id`
 
 See **dcx-bigquery** for authentication.
 
@@ -75,7 +77,7 @@ dcx ca ask --profile app-cloudsql.yaml "active users today"
 ## Constraints
 
 - CA API is currently in preview
-- Data agents are project-scoped and support BigQuery only
+- Data agents are project-scoped, BigQuery-only, and live at `locations/global`
 - Database sources (AlloyDB, Spanner, Cloud SQL) do not support data agents or visualizations
 - Looker profiles work with `ca ask` but not `ca create-agent`
 

--- a/skills/dcx-ca/references/create-agent.md
+++ b/skills/dcx-ca/references/create-agent.md
@@ -58,6 +58,8 @@ dcx ca add-verified-query \
 
 ## Notes
 
-- Creates resources — requires appropriate IAM permissions
+- Agent management always uses `locations/global` — the `--location` flag is ignored
+- Requires `roles/geminidataanalytics.dataAgentCreator` (or `roles/owner`)
+- Requires `geminidataanalytics.googleapis.com` and `cloudaicompanion.googleapis.com` APIs enabled
 - Table refs must be fully qualified: `project.dataset.table`
 - Only supports BigQuery tables/views


### PR DESCRIPTION
## Summary

- Update command count from 35 to 38 across README
- Document `locations/global` behavior for agent management commands (`--location` flag is ignored)
- Add required IAM role (`dataAgentCreator`) and APIs to create-agent reference
- Mark CA management as shipped (PR #7) in plan doc, remove from "Deferred to P1"
- Add agent management example to Quick Start

## Test plan

- [ ] `go test ./...` passes (docs-only change, no code touched)
- [ ] `dcx meta commands` confirms 38 total commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)