### PR TITLE
Fix Discovery framework for nested resource hierarchies

### DIFF
--- a/internal/discovery/executor.go
+++ b/internal/discovery/executor.go
@@ -201,16 +201,19 @@ func normalizeListResponse(raw map[string]interface{}, domain string) ListEnvelo
 }
 
 // extractItems finds the items array in a raw API response.
-// Different APIs use different keys for the items array.
+// Tries known keys first, then falls back to any top-level array-valued key
+// (skipping metadata keys like nextPageToken). This handles new resource types
+// without requiring code changes.
 func extractItems(raw map[string]interface{}) []interface{} {
-	// Common item keys used by Google APIs.
-	itemKeys := []string{
-		"datasets", "tables", "routines", "models",       // BigQuery
-		"instances", "databases", "clusters", "backups",    // Spanner/AlloyDB/CloudSQL/Looker
-		"items",                                            // generic fallback
+	// Known item keys used by Google APIs — checked first for determinism.
+	knownKeys := []string{
+		"datasets", "tables", "routines", "models", "jobs",   // BigQuery
+		"instances", "databases", "clusters", "backups",       // Spanner/AlloyDB/CloudSQL/Looker
+		"operations", "users", "backupRuns", "flags",          // additional surfaces
+		"items",                                               // generic
 	}
 
-	for _, key := range itemKeys {
+	for _, key := range knownKeys {
 		if items, ok := raw[key]; ok {
 			if arr, ok := items.([]interface{}); ok {
 				return arr
@@ -218,7 +221,19 @@ func extractItems(raw map[string]interface{}) []interface{} {
 		}
 	}
 
-	// If no known items key, return the raw response as a single item.
+	// Fallback: find any top-level key whose value is a JSON array,
+	// skipping pagination/metadata keys.
+	skip := map[string]bool{"nextPageToken": true, "kind": true, "etag": true}
+	for key, val := range raw {
+		if skip[key] {
+			continue
+		}
+		if arr, ok := val.([]interface{}); ok {
+			return arr
+		}
+	}
+
+	// Nothing found — return the raw response as a single item.
 	return []interface{}{raw}
 }
 
@@ -275,15 +290,17 @@ func validateRequiredParams(cmd GeneratedCommand, globalFlags map[string]string)
 				continue
 			}
 
-			// Check if param is "parent" and handled by template.
-			if paramName == "parent" && cmd.Service.ParentTemplate != "" {
-				template := cmd.Service.ParentTemplate
-				for name := range globalFlags {
-					template = strings.ReplaceAll(template, "{"+name+"}", "OK")
+			// Check if param is "parent" and handled by template or flatPath.
+			if paramName == "parent" {
+				if err := validateParentFlags(cmd, globalFlags); err != nil {
+					return err
 				}
-				if strings.Contains(template, "{") {
-					return fmt.Errorf("parent template requires flags not provided: %s", cmd.Service.ParentTemplate)
-				}
+				continue
+			}
+
+			// Skip full-resource-path params in flatPath services — these are
+			// validated via the individual flatPath segment flags.
+			if cmd.Service.UseFlatPath && isFullResourcePathParam(param.Pattern) {
 				continue
 			}
 
@@ -292,6 +309,61 @@ func validateRequiredParams(cmd GeneratedCommand, globalFlags map[string]string)
 				return fmt.Errorf("required flag --%s is missing", camelToKebab(paramName))
 			}
 		}
+	}
+
+	// For flatPath services, validate that all intermediate segment flags
+	// are provided.
+	if cmd.Service.UseFlatPath && cmd.Method.FlatPath != "" {
+		if err := validateFlatPathFlags(cmd, globalFlags); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateParentFlags checks that all flags needed for the parent are provided.
+// Uses the ParentTemplate for top-level parents and the flatPath for deeper ones.
+func validateParentFlags(cmd GeneratedCommand, globalFlags map[string]string) error {
+	if cmd.Service.ParentTemplate != "" {
+		template := cmd.Service.ParentTemplate
+		for name := range globalFlags {
+			template = strings.ReplaceAll(template, "{"+name+"}", "OK")
+		}
+		if strings.Contains(template, "{") {
+			return fmt.Errorf("parent template requires flags not provided: %s", cmd.Service.ParentTemplate)
+		}
+	}
+	// Intermediate flags are validated by validateFlatPathFlags.
+	return nil
+}
+
+// validateFlatPathFlags checks that all flatPath segment flags are provided.
+func validateFlatPathFlags(cmd GeneratedCommand, globalFlags map[string]string) error {
+	segments := parseFlatPathSegments(cmd.Method.FlatPath)
+	parentMap := buildParentFlagMap(cmd.Service.ParentTemplate)
+
+	for _, seg := range segments {
+		// Try ParentTemplate mapping.
+		if mapped, ok := parentMap[seg.IDKey]; ok {
+			if val, ok := globalFlags[mapped]; ok && val != "" {
+				continue
+			}
+			return fmt.Errorf("required flag --%s is missing", mapped)
+		}
+
+		// Try IDKey directly as a flag (CloudSQL style: {instance}).
+		if val, ok := globalFlags[seg.IDKey]; ok && val != "" {
+			continue
+		}
+
+		// Try derived flag name (Spanner style: {instancesId} → --instance-id).
+		flagName := deriveFlagName(seg.Resource)
+		if val, ok := globalFlags[flagName]; ok && val != "" {
+			continue
+		}
+
+		return fmt.Errorf("required flag --%s is missing", flagName)
 	}
 	return nil
 }

--- a/internal/discovery/flatpath.go
+++ b/internal/discovery/flatpath.go
@@ -1,0 +1,99 @@
+package discovery
+
+import "strings"
+
+// pathSegment represents a resource/{id} pair extracted from a flatPath.
+type pathSegment struct {
+	Resource string // e.g., "projects", "instances"
+	IDKey    string // e.g., "projectsId", "instancesId"
+}
+
+// parseFlatPathSegments extracts resource/{id} pairs from a flatPath.
+//
+// Example: "v1/projects/{projectsId}/instances/{instancesId}/databases"
+// returns: [{projects, projectsId}, {instances, instancesId}]
+//
+// The trailing resource (e.g., "databases") is excluded when it has no ID param.
+// If the path ends with a resource/{id} pair, both are included.
+func parseFlatPathSegments(flatPath string) []pathSegment {
+	parts := strings.Split(flatPath, "/")
+	var segments []pathSegment
+
+	for i := 0; i < len(parts)-1; i++ {
+		next := parts[i+1]
+		if strings.HasPrefix(next, "{") && strings.HasSuffix(next, "}") {
+			idKey := strings.Trim(next, "{}")
+			segments = append(segments, pathSegment{Resource: parts[i], IDKey: idKey})
+			i++ // skip the ID part
+		}
+	}
+
+	return segments
+}
+
+// buildParentFlagMap builds a mapping from flatPath ID keys to CLI flag names
+// using the service's ParentTemplate.
+//
+// Template "projects/{project-id}/locations/{location}" produces:
+//
+//	{"projectsId": "project-id", "locationsId": "location"}
+func buildParentFlagMap(parentTemplate string) map[string]string {
+	if parentTemplate == "" {
+		return nil
+	}
+	m := make(map[string]string)
+	parts := strings.Split(parentTemplate, "/")
+	for i := 0; i+1 < len(parts); i += 2 {
+		resource := parts[i]                     // e.g., "projects"
+		flagName := strings.Trim(parts[i+1], "{}") // e.g., "project-id"
+		flatKey := resource + "Id"               // e.g., "projectsId"
+		m[flatKey] = flagName
+	}
+	return m
+}
+
+// deriveFlagName converts a plural resource name to a CLI flag name.
+//
+//	"instances" → "instance-id"
+//	"clusters"  → "cluster-id"
+//	"backups"   → "backup-id"
+func deriveFlagName(resource string) string {
+	singular := resource
+	if strings.HasSuffix(singular, "ses") {
+		// e.g., "databases" → "database" (not "databas")
+		singular = singular[:len(singular)-1]
+	} else if strings.HasSuffix(singular, "s") {
+		singular = singular[:len(singular)-1]
+	}
+	return singular + "-id"
+}
+
+// isFullResourcePathParam returns true if a parameter's pattern indicates it
+// expects a full resource path (e.g., "projects/x/instances/x/databases/x")
+// rather than a simple ID value. These params are handled by flatPath segment
+// resolution and should not be exposed as individual CLI flags.
+//
+// Detects literal path separators like "projects/" in the pattern, while
+// ignoring "/" inside regex character classes like "[^/]".
+func isFullResourcePathParam(pattern string) bool {
+	if pattern == "" {
+		return false
+	}
+	// Check for "word/" pattern which indicates a literal resource path segment,
+	// e.g., "^projects/[^/]+/instances/[^/]+$" has "projects/" and "instances/".
+	// Simple ID patterns like "^[^/]+$" only have "/" inside character classes.
+	inCharClass := false
+	for i, ch := range pattern {
+		switch ch {
+		case '[':
+			inCharClass = true
+		case ']':
+			inCharClass = false
+		case '/':
+			if !inCharClass && i > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/discovery/flatpath_test.go
+++ b/internal/discovery/flatpath_test.go
@@ -1,0 +1,371 @@
+package discovery
+
+import (
+	"os"
+	"testing"
+)
+
+func TestParseFlatPathSegments(t *testing.T) {
+	tests := []struct {
+		name     string
+		flatPath string
+		want     []pathSegment
+	}{
+		{
+			name:     "spanner instances (top-level)",
+			flatPath: "v1/projects/{projectsId}/instances",
+			want:     []pathSegment{{Resource: "projects", IDKey: "projectsId"}},
+		},
+		{
+			name:     "spanner databases (nested under instances)",
+			flatPath: "v1/projects/{projectsId}/instances/{instancesId}/databases",
+			want: []pathSegment{
+				{Resource: "projects", IDKey: "projectsId"},
+				{Resource: "instances", IDKey: "instancesId"},
+			},
+		},
+		{
+			name:     "spanner databases get (nested with leaf ID)",
+			flatPath: "v1/projects/{projectsId}/instances/{instancesId}/databases/{databasesId}",
+			want: []pathSegment{
+				{Resource: "projects", IDKey: "projectsId"},
+				{Resource: "instances", IDKey: "instancesId"},
+				{Resource: "databases", IDKey: "databasesId"},
+			},
+		},
+		{
+			name:     "alloydb instances (3-level nesting)",
+			flatPath: "v1/projects/{projectsId}/locations/{locationsId}/clusters/{clustersId}/instances",
+			want: []pathSegment{
+				{Resource: "projects", IDKey: "projectsId"},
+				{Resource: "locations", IDKey: "locationsId"},
+				{Resource: "clusters", IDKey: "clustersId"},
+			},
+		},
+		{
+			name:     "cloudsql databases (simple param names)",
+			flatPath: "v1/projects/{project}/instances/{instance}/databases",
+			want: []pathSegment{
+				{Resource: "projects", IDKey: "project"},
+				{Resource: "instances", IDKey: "instance"},
+			},
+		},
+		{
+			name:     "bigquery datasets (no version prefix)",
+			flatPath: "projects/{projectsId}/datasets",
+			want:     []pathSegment{{Resource: "projects", IDKey: "projectsId"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseFlatPathSegments(tt.flatPath)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d segments, want %d: %+v", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("segment[%d] = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestDeriveFlagName(t *testing.T) {
+	tests := []struct {
+		resource string
+		want     string
+	}{
+		{"instances", "instance-id"},
+		{"clusters", "cluster-id"},
+		{"databases", "database-id"},
+		{"backups", "backup-id"},
+		{"projects", "project-id"},
+		{"locations", "location-id"},
+	}
+	for _, tt := range tests {
+		got := deriveFlagName(tt.resource)
+		if got != tt.want {
+			t.Errorf("deriveFlagName(%q) = %q, want %q", tt.resource, got, tt.want)
+		}
+	}
+}
+
+func TestBuildParentFlagMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		want     map[string]string
+	}{
+		{
+			name:     "spanner",
+			template: "projects/{project-id}",
+			want:     map[string]string{"projectsId": "project-id"},
+		},
+		{
+			name:     "alloydb",
+			template: "projects/{project-id}/locations/{location}",
+			want: map[string]string{
+				"projectsId":  "project-id",
+				"locationsId": "location",
+			},
+		},
+		{
+			name:     "empty",
+			template: "",
+			want:     nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildParentFlagMap(tt.template)
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("expected nil, got %v", got)
+				}
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d entries, want %d: %v", len(got), len(tt.want), got)
+			}
+			for k, v := range tt.want {
+				if got[k] != v {
+					t.Errorf("key %q = %q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestIsFullResourcePathParam(t *testing.T) {
+	tests := []struct {
+		pattern string
+		want    bool
+	}{
+		{"^projects/[^/]+/instances/[^/]+$", true},
+		{"^[^/]+$", false},
+		{"-", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		got := isFullResourcePathParam(tt.pattern)
+		if got != tt.want {
+			t.Errorf("isFullResourcePathParam(%q) = %v, want %v", tt.pattern, got, tt.want)
+		}
+	}
+}
+
+// TestSpannerDatabasesListInfersInstanceIdFlag verifies that parsing Spanner's
+// databases.list method adds an instance-id CLI flag from the flatPath.
+func TestSpannerDatabasesListInfersInstanceIdFlag(t *testing.T) {
+	docJSON, err := os.ReadFile("../../assets/spanner_v1_discovery.json")
+	if err != nil {
+		t.Fatalf("reading discovery doc: %v", err)
+	}
+
+	svc := SpannerConfig()
+	commands, err := Parse(docJSON, svc)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	var dbListCmd *GeneratedCommand
+	for i := range commands {
+		if commands[i].CommandPath == "spanner databases list" {
+			dbListCmd = &commands[i]
+			break
+		}
+	}
+	if dbListCmd == nil {
+		t.Fatal("spanner databases list not found")
+	}
+
+	hasInstanceId := false
+	for _, f := range dbListCmd.CommandFlags {
+		if f.Name == "instance-id" {
+			hasInstanceId = true
+			if !f.Required {
+				t.Error("instance-id should be required")
+			}
+			if f.Location != "path" {
+				t.Errorf("instance-id location = %q, want path", f.Location)
+			}
+		}
+	}
+	if !hasInstanceId {
+		names := flagNames(dbListCmd.CommandFlags)
+		t.Errorf("spanner databases list must have instance-id flag; got: %v", names)
+	}
+}
+
+// TestSpannerDatabasesGetInfersFlags verifies that databases.get gets both
+// instance-id and database-id flags, and does NOT expose the full-path "name" param.
+func TestSpannerDatabasesGetInfersFlags(t *testing.T) {
+	docJSON, err := os.ReadFile("../../assets/spanner_v1_discovery.json")
+	if err != nil {
+		t.Fatalf("reading discovery doc: %v", err)
+	}
+
+	svc := SpannerConfig()
+	commands, err := Parse(docJSON, svc)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	var dbGetCmd *GeneratedCommand
+	for i := range commands {
+		if commands[i].CommandPath == "spanner databases get" {
+			dbGetCmd = &commands[i]
+			break
+		}
+	}
+	if dbGetCmd == nil {
+		t.Fatal("spanner databases get not found")
+	}
+
+	flags := make(map[string]bool)
+	for _, f := range dbGetCmd.CommandFlags {
+		flags[f.Name] = true
+	}
+
+	if !flags["instance-id"] {
+		t.Errorf("missing instance-id flag; got: %v", flagNames(dbGetCmd.CommandFlags))
+	}
+	if !flags["database-id"] {
+		t.Errorf("missing database-id flag; got: %v", flagNames(dbGetCmd.CommandFlags))
+	}
+	if flags["name"] {
+		t.Error("full-resource-path 'name' param should not be exposed as a CLI flag")
+	}
+}
+
+// TestAlloyDBInstancesListInfersClusterIdFlag verifies that AlloyDB instances.list
+// gets a cluster-id flag from the flatPath.
+func TestAlloyDBInstancesListInfersClusterIdFlag(t *testing.T) {
+	docJSON, err := os.ReadFile("../../assets/alloydb_v1_discovery.json")
+	if err != nil {
+		t.Fatalf("reading discovery doc: %v", err)
+	}
+
+	svc := AlloyDBConfig()
+	commands, err := Parse(docJSON, svc)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	var instListCmd *GeneratedCommand
+	for i := range commands {
+		if commands[i].CommandPath == "alloydb instances list" {
+			instListCmd = &commands[i]
+			break
+		}
+	}
+	if instListCmd == nil {
+		t.Fatal("alloydb instances list not found")
+	}
+
+	hasClusterId := false
+	for _, f := range instListCmd.CommandFlags {
+		if f.Name == "cluster-id" {
+			hasClusterId = true
+			if !f.Required {
+				t.Error("cluster-id should be required")
+			}
+		}
+	}
+	if !hasClusterId {
+		t.Errorf("alloydb instances list must have cluster-id flag; got: %v",
+			flagNames(instListCmd.CommandFlags))
+	}
+}
+
+// TestCloudSQLDatabasesListKeepsInstanceFlag verifies that CloudSQL's existing
+// individual "instance" param is NOT replaced by a derived "instance-id" flag.
+func TestCloudSQLDatabasesListKeepsInstanceFlag(t *testing.T) {
+	docJSON, err := os.ReadFile("../../assets/sqladmin_v1_discovery.json")
+	if err != nil {
+		t.Fatalf("reading discovery doc: %v", err)
+	}
+
+	svc := CloudSQLConfig()
+	commands, err := Parse(docJSON, svc)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	var dbListCmd *GeneratedCommand
+	for i := range commands {
+		if commands[i].CommandPath == "cloudsql databases list" {
+			dbListCmd = &commands[i]
+			break
+		}
+	}
+	if dbListCmd == nil {
+		t.Fatal("cloudsql databases list not found")
+	}
+
+	flags := make(map[string]bool)
+	for _, f := range dbListCmd.CommandFlags {
+		flags[f.Name] = true
+	}
+
+	if !flags["instance"] {
+		t.Errorf("CloudSQL must keep 'instance' flag; got: %v", flagNames(dbListCmd.CommandFlags))
+	}
+	if flags["instance-id"] {
+		t.Error("CloudSQL should NOT have derived 'instance-id' flag (uses 'instance' directly)")
+	}
+}
+
+// TestExtractItemsDynamic verifies extractItems handles non-standard keys.
+func TestExtractItemsDynamic(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  map[string]interface{}
+		want int
+	}{
+		{
+			name: "known key: databases",
+			raw:  map[string]interface{}{"databases": []interface{}{"a", "b"}, "nextPageToken": "x"},
+			want: 2,
+		},
+		{
+			name: "known key: operations",
+			raw:  map[string]interface{}{"operations": []interface{}{"op1"}},
+			want: 1,
+		},
+		{
+			name: "known key: users",
+			raw:  map[string]interface{}{"users": []interface{}{"u1", "u2", "u3"}},
+			want: 3,
+		},
+		{
+			name: "unknown key falls back to array scan",
+			raw:  map[string]interface{}{"databaseRoles": []interface{}{"role1"}, "nextPageToken": "x"},
+			want: 1,
+		},
+		{
+			name: "no array returns raw as single item",
+			raw:  map[string]interface{}{"name": "projects/x/databases/y"},
+			want: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			items := extractItems(tt.raw)
+			if len(items) != tt.want {
+				t.Errorf("got %d items, want %d", len(items), tt.want)
+			}
+		})
+	}
+}
+
+func flagNames(flags []ApiParam) []string {
+	var names []string
+	for _, f := range flags {
+		names = append(names, f.Name)
+	}
+	return names
+}

--- a/internal/discovery/parser.go
+++ b/internal/discovery/parser.go
@@ -103,7 +103,13 @@ func extractMethods(
 			cmdPath = camelToKebab(cmdPath)
 
 			// Separate global-mapped params from command-specific flags.
-			cmdFlags := extractCommandFlags(apiMethod.Parameters, svc.GlobalParamMappings)
+			cmdFlags := extractCommandFlags(apiMethod.Parameters, svc)
+
+			// For flatPath services, infer CLI flags for intermediate
+			// resource IDs not covered by the ParentTemplate.
+			if svc.UseFlatPath && apiMethod.FlatPath != "" {
+				cmdFlags = append(cmdFlags, inferFlatPathFlags(apiMethod.FlatPath, svc, cmdFlags)...)
+			}
 
 			*out = append(*out, GeneratedCommand{
 				CommandPath:  cmdPath,
@@ -138,20 +144,27 @@ func convertParams(params map[string]discoveryParam) map[string]ApiParam {
 
 // extractCommandFlags returns params that should become CLI flags.
 // This includes query params AND path params that are not handled by
-// global flag mappings or parent templates.
-func extractCommandFlags(params map[string]ApiParam, globalMappings map[string]string) []ApiParam {
+// global flag mappings, parent templates, or flatPath segment resolution.
+func extractCommandFlags(params map[string]ApiParam, svc *ServiceConfig) []ApiParam {
 	var flags []ApiParam
 	for name, param := range params {
 		// Skip if this param is mapped to a global flag.
-		if _, isGlobal := globalMappings[name]; isGlobal {
+		if _, isGlobal := svc.GlobalParamMappings[name]; isGlobal {
 			continue
 		}
-		// Skip "parent" param — constructed from global flags via ParentTemplate.
+		// Skip "parent" param — constructed from global flags via ParentTemplate
+		// or flatPath segment resolution.
 		if name == "parent" {
 			continue
 		}
 		// Skip pagination params — handled by dedicated --page-token/--page-all flags.
 		if name == "pageToken" || name == "pageSize" {
+			continue
+		}
+		// For flatPath services, skip path params whose pattern contains "/"
+		// (full resource paths like "projects/x/instances/x/databases/x").
+		// These are constructed from individual flatPath segment flags.
+		if svc.UseFlatPath && param.Location == "path" && isFullResourcePathParam(param.Pattern) {
 			continue
 		}
 		// Include both query params and non-global path params (resource IDs
@@ -161,6 +174,61 @@ func extractCommandFlags(params map[string]ApiParam, globalMappings map[string]s
 		}
 	}
 	return flags
+}
+
+// inferFlatPathFlags parses the flatPath to find intermediate resource IDs
+// that aren't covered by the ParentTemplate, GlobalParamMappings, or
+// already-extracted flags. Returns additional CLI flags needed for nested
+// resource resolution.
+func inferFlatPathFlags(flatPath string, svc *ServiceConfig, existingFlags []ApiParam) []ApiParam {
+	segments := parseFlatPathSegments(flatPath)
+	parentMap := buildParentFlagMap(svc.ParentTemplate)
+
+	// Build sets for dedup — include existing flag names AND raw IDKeys
+	// (CloudSQL uses {instance} not {instancesId}, and the flag name matches).
+	existing := make(map[string]bool)
+	for _, f := range existingFlags {
+		existing[f.Name] = true
+	}
+	for _, flagName := range svc.GlobalParamMappings {
+		existing[flagName] = true
+	}
+	for paramName := range svc.GlobalParamMappings {
+		existing[paramName] = true
+	}
+
+	var newFlags []ApiParam
+	for _, seg := range segments {
+		// Skip if handled by ParentTemplate.
+		if _, ok := parentMap[seg.IDKey]; ok {
+			continue
+		}
+		// Skip if the IDKey itself matches an existing flag (CloudSQL style).
+		if existing[seg.IDKey] {
+			continue
+		}
+
+		flagName := deriveFlagName(seg.Resource)
+		if existing[flagName] {
+			continue
+		}
+		existing[flagName] = true
+
+		singular := seg.Resource
+		if strings.HasSuffix(singular, "s") {
+			singular = singular[:len(singular)-1]
+		}
+
+		newFlags = append(newFlags, ApiParam{
+			Name:        flagName,
+			Type:        "string",
+			Description: singular + " ID",
+			Location:    "path",
+			Required:    true,
+		})
+	}
+
+	return newFlags
 }
 
 // camelToKebab converts camelCase segments in a space-separated path

--- a/internal/discovery/register.go
+++ b/internal/discovery/register.go
@@ -110,8 +110,7 @@ func registerOneCommand(
 			queryParams := make(map[string]string)
 			for name, val := range flagValues {
 				if *val != "" {
-					// Check if this flag is a path param — feed it into path resolution.
-					if param, ok := cmd.Method.Parameters[name]; ok && param.Location == "path" {
+					if isCommandPathFlag(name, cmd) {
 						globalFlags[name] = *val
 					} else {
 						queryParams[name] = *val
@@ -175,4 +174,18 @@ func registerOneCommand(
 		false, // Discovery GET commands are not mutations
 		false, // No dry-run for Discovery commands
 	))
+}
+
+// isCommandPathFlag checks if a flag name is a path parameter, checking both
+// the Discovery method parameters and the inferred flatPath flags.
+func isCommandPathFlag(name string, cmd GeneratedCommand) bool {
+	if param, ok := cmd.Method.Parameters[name]; ok && param.Location == "path" {
+		return true
+	}
+	for _, f := range cmd.CommandFlags {
+		if f.Name == name && f.Location == "path" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/discovery/request.go
+++ b/internal/discovery/request.go
@@ -135,11 +135,23 @@ func ResolvePathParams(cmd GeneratedCommand, globalFlags map[string]string) (map
 		if paramName == "parent" {
 			continue
 		}
+		// Skip full-resource-path params in flatPath services — these are
+		// resolved by flatPath segment expansion below.
+		if cmd.Service.UseFlatPath && isFullResourcePathParam(param.Pattern) {
+			continue
+		}
 		if val, ok := globalFlags[paramName]; ok && val != "" {
 			pathParams[paramName] = val
 			flatKey := toFlatPathKey(paramName)
 			pathParams[flatKey] = val
 		}
+	}
+
+	// For flatPath services, resolve ALL {xxxId} segments from the flatPath
+	// using global flags. This handles intermediate parents (e.g., instancesId)
+	// that aren't in the ParentTemplate.
+	if cmd.Service.UseFlatPath && cmd.Method.FlatPath != "" {
+		resolveFlatPathSegments(pathParams, cmd.Method.FlatPath, cmd.Service.ParentTemplate, globalFlags)
 	}
 
 	return pathParams, nil
@@ -171,6 +183,42 @@ func expandFlatPathParams(params map[string]string, template string, flags map[s
 		if val, ok := flags[flagName]; ok && val != "" {
 			flatKey := resource[:len(resource)] + "Id" // e.g. "projectsId"
 			params[flatKey] = val
+		}
+	}
+}
+
+// resolveFlatPathSegments resolves ALL {xxxId} segments in a flatPath from
+// global flags. Uses the ParentTemplate for known mappings, then tries the
+// IDKey directly (CloudSQL style: {instance}), then derives flag names for
+// unknown segments (Spanner style: {instancesId}).
+func resolveFlatPathSegments(params map[string]string, flatPath, parentTemplate string, flags map[string]string) {
+	segments := parseFlatPathSegments(flatPath)
+	parentMap := buildParentFlagMap(parentTemplate)
+
+	for _, seg := range segments {
+		// Skip if already resolved.
+		if _, ok := params[seg.IDKey]; ok {
+			continue
+		}
+
+		// Try ParentTemplate mapping first.
+		if mapped, ok := parentMap[seg.IDKey]; ok {
+			if val, ok := flags[mapped]; ok && val != "" {
+				params[seg.IDKey] = val
+				continue
+			}
+		}
+
+		// Try the IDKey directly as a flag name (CloudSQL style: {instance}).
+		if val, ok := flags[seg.IDKey]; ok && val != "" {
+			params[seg.IDKey] = val
+			continue
+		}
+
+		// Derive flag name from resource name (Spanner style: {instancesId}).
+		flagName := deriveFlagName(seg.Resource)
+		if val, ok := flags[flagName]; ok && val != "" {
+			params[seg.IDKey] = val
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Fix nested parent resolution: commands like `spanner databases list` and `alloydb instances list` failed with "unresolved path parameter" because `ParentTemplate` only covered the top-level parent. The framework now parses the flatPath to derive intermediate CLI flags (`--instance-id`, `--cluster-id`) and resolves all segments at request time
- Fix dynamic list-key extraction: `extractItems()` was hardcoded to 9 response keys. Now tries known keys first, then falls back to any top-level array in the response — unblocking new surfaces like `operations`, `users`, `backupRuns`, `flags`
- No service-specific special cases — the mechanism is general and driven by the flatPath in each Discovery document
- Handles both flatPath naming conventions: `{instancesId}` (Spanner/AlloyDB/Looker) and `{instance}` (CloudSQL)

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` passes (15 new test cases in `flatpath_test.go`)
- [x] Previously-broken commands now resolve paths: `spanner databases list/get/get-ddl`, `alloydb instances list/get`
- [x] Existing commands unaffected: BigQuery, CloudSQL, Looker, top-level Spanner/AlloyDB
- [x] Missing intermediate flags give clear errors: `required flag --instance-id is missing`
- [x] Live API test: `spanner databases list --project-id=X --instance-id=Y` returns correct NOT_FOUND with proper resource path

🤖 Generated with [Claude Code](https://claude.com/claude-code)