### PR TITLE
Add streaming output for CA chat API

### DIFF
--- a/internal/ca/client.go
+++ b/internal/ca/client.go
@@ -1,6 +1,7 @@
 package ca
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -48,15 +49,24 @@ func NewClient(httpClient *http.Client) *Client {
 // Spanner/AlloyDB/CloudSQL use :queryData (NL-to-SQL).
 // This matches the working Rust implementation.
 func (c *Client) Ask(ctx context.Context, token string, profile *profiles.Profile, question, agent, tables string) (*AskResult, error) {
+	return c.AskStream(ctx, token, profile, question, agent, tables, nil)
+}
+
+// AskStream is like Ask but accepts an optional StreamCallback that is called
+// for each message as it arrives from the chat API. This enables real-time
+// display of thinking steps and the final answer. If cb is nil, behaves
+// identically to Ask. QueryData sources ignore the callback.
+func (c *Client) AskStream(ctx context.Context, token string, profile *profiles.Profile, question, agent, tables string, cb StreamCallback) (*AskResult, error) {
 	if profile != nil && profile.IsQueryDataSource() {
 		return c.askQueryData(ctx, token, profile, question)
 	}
-	return c.askChat(ctx, token, profile, question, agent, tables)
+	return c.askChat(ctx, token, profile, question, agent, tables, cb)
 }
 
 // askChat sends a question to the :chat endpoint (BigQuery/Looker/Studio).
 // Uses messages + userMessage + inlineContext structure.
-func (c *Client) askChat(ctx context.Context, token string, profile *profiles.Profile, question, agent, tables string) (*AskResult, error) {
+// If cb is non-nil, each message is streamed to the callback as it arrives.
+func (c *Client) askChat(ctx context.Context, token string, profile *profiles.Profile, question, agent, tables string, cb StreamCallback) (*AskResult, error) {
 	projectID := ""
 	location := "us"
 	if profile != nil {
@@ -136,13 +146,8 @@ func (c *Client) askChat(ctx context.Context, token string, profile *profiles.Pr
 		return nil, readAPIError(resp)
 	}
 
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading chat response: %w", err)
-	}
-
-	// Parse streaming response (JSON array of messages).
-	result, err := parseChatResponse(respBody, question, agent)
+	// Parse the streaming response, invoking cb for each message if provided.
+	result, err := parseStreamingChat(resp.Body, question, agent, cb)
 	if err != nil {
 		return nil, err
 	}
@@ -698,6 +703,164 @@ func buildQueryDataDatasourceRef(profile *profiles.Profile) map[string]interface
 	default:
 		return nil
 	}
+}
+
+// parseStreamingChat reads the chat response body and dispatches each message
+// to the callback as it arrives from the network. Handles both wire formats:
+//   - JSON array: streamed incrementally via json.NewDecoder (common case)
+//   - Newline-delimited: read line by line from a bufio.Scanner (fallback)
+//
+// The complete AskResult is returned at the end regardless of format.
+func parseStreamingChat(body io.Reader, question, agent string, cb StreamCallback) (*AskResult, error) {
+	// Peek at the first non-whitespace byte to detect the wire format
+	// without consuming the stream.
+	br := bufio.NewReader(body)
+	firstByte, err := peekNonSpace(br)
+	if err != nil {
+		return nil, fmt.Errorf("reading chat response: %w", err)
+	}
+
+	var messages []map[string]interface{}
+
+	if firstByte == '[' {
+		// JSON array — stream directly from the response body.
+		decoder := json.NewDecoder(br)
+
+		// Consume opening '['.
+		if _, err := decoder.Token(); err != nil {
+			return nil, fmt.Errorf("parsing chat response array: %w", err)
+		}
+		for decoder.More() {
+			var msg map[string]interface{}
+			if err := decoder.Decode(&msg); err != nil {
+				return nil, fmt.Errorf("parsing chat message: %w", err)
+			}
+			messages = append(messages, msg)
+			dispatchStreamEvent(msg, cb)
+		}
+	} else {
+		// Newline-delimited — read line by line from the response body.
+		scanner := bufio.NewScanner(br)
+		scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" || line == "," {
+				continue
+			}
+			var msg map[string]interface{}
+			if err := json.Unmarshal([]byte(line), &msg); err != nil {
+				continue // skip unparseable lines
+			}
+			messages = append(messages, msg)
+			dispatchStreamEvent(msg, cb)
+		}
+		if err := scanner.Err(); err != nil {
+			return nil, fmt.Errorf("reading chat response lines: %w", err)
+		}
+	}
+
+	return buildAskResult(messages, question, agent), nil
+}
+
+// peekNonSpace reads ahead in a bufio.Reader until a non-whitespace byte
+// is found, returning that byte without consuming it.
+func peekNonSpace(br *bufio.Reader) (byte, error) {
+	for {
+		b, err := br.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		if b != ' ' && b != '\t' && b != '\n' && b != '\r' {
+			if err := br.UnreadByte(); err != nil {
+				return 0, err
+			}
+			return b, nil
+		}
+	}
+}
+
+// dispatchStreamEvent sends a single message to the callback if non-nil.
+func dispatchStreamEvent(msg map[string]interface{}, cb StreamCallback) {
+	if cb == nil {
+		return
+	}
+	sm, ok := msg["systemMessage"].(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	if text, ok := sm["text"].(map[string]interface{}); ok {
+		textType, _ := text["textType"].(string)
+		parts := extractTextParts(text)
+		if len(parts) == 0 {
+			return
+		}
+		switch textType {
+		case "FINAL_RESPONSE":
+			cb(StreamEvent{Type: EventAnswer, Text: strings.Join(parts, "\n")})
+		default:
+			cb(StreamEvent{Type: EventThinking, Text: parts[0]})
+		}
+	}
+
+	if data, ok := sm["data"].(map[string]interface{}); ok {
+		if sql, ok := data["generatedSql"].(string); ok {
+			cb(StreamEvent{Type: EventSQL, Text: sql})
+		}
+		if _, ok := data["result"]; ok {
+			cb(StreamEvent{Type: EventResult})
+		}
+	}
+}
+
+// buildAskResult extracts the final answer from a list of parsed messages.
+func buildAskResult(messages []map[string]interface{}, question, agent string) *AskResult {
+	result := &AskResult{
+		Question: question,
+		Agent:    agent,
+	}
+	for _, msg := range messages {
+		sm, ok := msg["systemMessage"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if text, ok := sm["text"].(map[string]interface{}); ok {
+			textType, _ := text["textType"].(string)
+			if textType == "FINAL_RESPONSE" {
+				for _, s := range extractTextParts(text) {
+					if result.Explanation == "" {
+						result.Explanation = s
+					} else {
+						result.Explanation += "\n" + s
+					}
+				}
+			}
+		}
+		if data, ok := sm["data"].(map[string]interface{}); ok {
+			if sql, ok := data["generatedSql"].(string); ok {
+				result.SQL = sql
+			}
+			if qr, ok := data["result"]; ok {
+				result.Results = qr
+			}
+		}
+	}
+	return result
+}
+
+// extractTextParts extracts string parts from a text message.
+func extractTextParts(text map[string]interface{}) []string {
+	parts, ok := text["parts"].([]interface{})
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, p := range parts {
+		if s, ok := p.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // parseChatResponse parses the streaming chat response (JSON array of messages)

--- a/internal/ca/client_test.go
+++ b/internal/ca/client_test.go
@@ -2,6 +2,7 @@ package ca
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/haiyuan-eng-google/dcx-cli/internal/profiles"
@@ -101,6 +102,158 @@ func TestDataAgentJSONShape(t *testing.T) {
 	}
 	if eq["sqlQuery"] != "SELECT COUNT(*) FROM events" {
 		t.Errorf("sqlQuery = %v", eq["sqlQuery"])
+	}
+}
+
+// --- parseStreamingChat tests ---
+
+// jsonArrayResponse is a realistic JSON array wire format.
+const jsonArrayResponse = `[
+  {"systemMessage":{"text":{"parts":["Analyzing context"],"textType":"THINKING"}}},
+  {"systemMessage":{"text":{"parts":["Counting rows"],"textType":"THINKING"}}},
+  {"systemMessage":{"data":{"generatedSql":"SELECT COUNT(*) FROM t"}}},
+  {"systemMessage":{"data":{"result":{"data":[{"count":42}]}}}},
+  {"systemMessage":{"text":{"parts":["There are 42 rows."],"textType":"FINAL_RESPONSE"}}},
+  {"systemMessage":{"text":{"parts":["How many columns?"],"textType":"SUGGESTED_QUESTION"}}}
+]`
+
+// newlineDelimitedResponse is the same content in newline-delimited format.
+const newlineDelimitedResponse = `{"systemMessage":{"text":{"parts":["Analyzing context"],"textType":"THINKING"}}}
+{"systemMessage":{"text":{"parts":["Counting rows"],"textType":"THINKING"}}}
+{"systemMessage":{"data":{"generatedSql":"SELECT COUNT(*) FROM t"}}}
+{"systemMessage":{"data":{"result":{"data":[{"count":42}]}}}}
+{"systemMessage":{"text":{"parts":["There are 42 rows."],"textType":"FINAL_RESPONSE"}}}
+{"systemMessage":{"text":{"parts":["How many columns?"],"textType":"SUGGESTED_QUESTION"}}}`
+
+func TestParseStreamingChat_JSONArray(t *testing.T) {
+	result, err := parseStreamingChat(
+		strings.NewReader(jsonArrayResponse), "how many?", "my-agent", nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertAskResult(t, result, "my-agent")
+}
+
+func TestParseStreamingChat_NewlineDelimited(t *testing.T) {
+	result, err := parseStreamingChat(
+		strings.NewReader(newlineDelimitedResponse), "how many?", "my-agent", nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertAskResult(t, result, "my-agent")
+}
+
+func TestParseStreamingChat_LeadingWhitespace(t *testing.T) {
+	// JSON array with leading whitespace — peekNonSpace should skip it.
+	result, err := parseStreamingChat(
+		strings.NewReader("  \n\t"+jsonArrayResponse), "q", "", nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.SQL != "SELECT COUNT(*) FROM t" {
+		t.Errorf("SQL = %q", result.SQL)
+	}
+}
+
+func TestParseStreamingChat_EmptyBody(t *testing.T) {
+	_, err := parseStreamingChat(
+		strings.NewReader(""), "q", "", nil,
+	)
+	if err == nil {
+		t.Fatal("expected error for empty body")
+	}
+}
+
+func TestParseStreamingChat_MalformedArrayElement(t *testing.T) {
+	// A broken message inside a JSON array should return an error.
+	body := `[{"systemMessage":{"text":{"parts":["ok"],"textType":"THINKING"}}}, INVALID]`
+	_, err := parseStreamingChat(strings.NewReader(body), "q", "", nil)
+	if err == nil {
+		t.Fatal("expected error for malformed array element")
+	}
+}
+
+func TestParseStreamingChat_Callback(t *testing.T) {
+	var events []StreamEvent
+	cb := func(e StreamEvent) {
+		events = append(events, e)
+	}
+
+	_, err := parseStreamingChat(
+		strings.NewReader(jsonArrayResponse), "q", "", cb,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Expected events: 2 thinking + 1 SQL + 1 result + 1 answer + 1 thinking (suggested question)
+	if len(events) < 5 {
+		t.Fatalf("expected at least 5 events, got %d: %+v", len(events), events)
+	}
+
+	// First two should be thinking.
+	if events[0].Type != EventThinking || events[0].Text != "Analyzing context" {
+		t.Errorf("event[0] = %+v, want thinking 'Analyzing context'", events[0])
+	}
+	if events[1].Type != EventThinking || events[1].Text != "Counting rows" {
+		t.Errorf("event[1] = %+v, want thinking 'Counting rows'", events[1])
+	}
+
+	// Find the SQL event.
+	foundSQL := false
+	for _, e := range events {
+		if e.Type == EventSQL && e.Text == "SELECT COUNT(*) FROM t" {
+			foundSQL = true
+		}
+	}
+	if !foundSQL {
+		t.Error("missing EventSQL with expected query")
+	}
+
+	// Find the answer event.
+	foundAnswer := false
+	for _, e := range events {
+		if e.Type == EventAnswer && e.Text == "There are 42 rows." {
+			foundAnswer = true
+		}
+	}
+	if !foundAnswer {
+		t.Error("missing EventAnswer with expected text")
+	}
+}
+
+func TestParseStreamingChat_NilCallback(t *testing.T) {
+	// Ensure nil callback doesn't panic.
+	result, err := parseStreamingChat(
+		strings.NewReader(jsonArrayResponse), "q", "", nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Explanation == "" {
+		t.Error("expected non-empty explanation")
+	}
+}
+
+func assertAskResult(t *testing.T, result *AskResult, wantAgent string) {
+	t.Helper()
+	if result.Question != "how many?" {
+		t.Errorf("Question = %q, want 'how many?'", result.Question)
+	}
+	if result.Agent != wantAgent {
+		t.Errorf("Agent = %q, want %q", result.Agent, wantAgent)
+	}
+	if result.SQL != "SELECT COUNT(*) FROM t" {
+		t.Errorf("SQL = %q, want 'SELECT COUNT(*) FROM t'", result.SQL)
+	}
+	if result.Explanation != "There are 42 rows." {
+		t.Errorf("Explanation = %q, want 'There are 42 rows.'", result.Explanation)
+	}
+	if result.Results == nil {
+		t.Error("Results should not be nil")
 	}
 }
 

--- a/internal/ca/models.go
+++ b/internal/ca/models.go
@@ -114,3 +114,26 @@ type AskResult struct {
 	Source      string      `json:"source,omitempty"`
 	Agent       string      `json:"agent,omitempty"`
 }
+
+// StreamEventType identifies the kind of streaming event from the chat API.
+type StreamEventType int
+
+const (
+	// EventThinking is an intermediate thinking/progress message.
+	EventThinking StreamEventType = iota
+	// EventAnswer is the final natural-language response.
+	EventAnswer
+	// EventSQL is the generated SQL query.
+	EventSQL
+	// EventResult is the query result data.
+	EventResult
+)
+
+// StreamEvent represents a single incremental event from the chat API.
+type StreamEvent struct {
+	Type StreamEventType
+	Text string // text content (thinking step, answer, or SQL)
+}
+
+// StreamCallback is called for each event during streaming chat responses.
+type StreamCallback func(event StreamEvent)

--- a/internal/cli/ca.go
+++ b/internal/cli/ca.go
@@ -123,7 +123,21 @@ func (a *App) caAskCmd() *cobra.Command {
 			}
 
 			client := ca.NewClient(nil)
-			result, err := client.Ask(ctx, tok.AccessToken, profile, question, agent, tables)
+
+			// Stream thinking steps to stderr for text format.
+			var cb ca.StreamCallback
+			if format == output.Text {
+				cb = func(event ca.StreamEvent) {
+					switch event.Type {
+					case ca.EventThinking:
+						fmt.Fprintf(os.Stderr, "\033[2m%s\033[0m\n", event.Text)
+					case ca.EventSQL:
+						fmt.Fprintf(os.Stderr, "\033[2mSQL: %s\033[0m\n", truncateSQL(event.Text, 120))
+					}
+				}
+			}
+
+			result, err := client.AskStream(ctx, tok.AccessToken, profile, question, agent, tables, cb)
 			if err != nil {
 				code := dcxerrors.APIError
 				dcxerrors.Emit(code, err.Error(), "")
@@ -370,4 +384,13 @@ var agentIDPattern = regexp.MustCompile(`^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$`)
 // isValidAgentID checks if an agent ID matches the API-documented format.
 func isValidAgentID(id string) bool {
 	return agentIDPattern.MatchString(id)
+}
+
+// truncateSQL shortens a SQL string for display, collapsing whitespace.
+func truncateSQL(sql string, maxLen int) string {
+	s := strings.Join(strings.Fields(sql), " ")
+	if len(s) > maxLen {
+		return s[:maxLen-3] + "..."
+	}
+	return s
 }


### PR DESCRIPTION
## Summary

- Stream CA chat API messages in real-time instead of buffering the entire response
- Uses `json.NewDecoder` to read each message as it arrives from the API
- With `--format=text`, thinking steps and SQL display on stderr with dim styling while the API processes
- JSON and other formats are unaffected — same buffered behavior as before
- New `AskStream` method with `StreamCallback` for programmatic consumers

## Example

```
$ dcx ca ask "how many rows?" --tables=myproject.data.metrics --format=text
Analyzing context          ← streams to stderr in real-time
Counting Rows              ← streams to stderr
SQL: SELECT COUNT(*)...    ← streams to stderr
<final answer on stdout>
```

## Test plan

- [x] `go vet ./...` clean, `go test ./...` passes
- [x] `--format=text` streams thinking steps to stderr in real-time
- [x] `--format=json` (default) returns complete buffered output, no streaming noise
- [x] `Ask()` (non-streaming) unchanged for existing callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)