### PR TITLE
Expand read commands Tier 2: backups and users across all services

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An agent-native CLI for Google Cloud's Data Cloud, built in Go.
 One binary for BigQuery, Spanner, AlloyDB, Cloud SQL, and Looker —
 with structured output, typed errors, and an MCP bridge for AI agents.
 
-> **Status:** Go MVP functional — 38 commands across 10 domains.
+> **Status:** Go MVP functional — 58 commands across 10 domains.
 > Benchmarked at **5x faster** than `bq` with token cost within 6%.
 > See [docs/benchmark_results_bigquery.md](docs/benchmark_results_bigquery.md)
 > for measured results.
@@ -51,15 +51,15 @@ dcx ca ask "revenue by region this quarter" --agent=sales-agent --project-id=myp
 dcx mcp serve
 ```
 
-## Commands (38 total)
+## Commands (58 total)
 
 | Surface | Commands |
 |---|---|
-| **BigQuery** | `datasets list/get`, `tables list/get`, `jobs query` (with `--dry-run`) |
-| **Spanner** | `instances list/get`, `databases list/get/get-ddl`, `schema describe` |
-| **AlloyDB** | `clusters list/get`, `instances list/get`, `databases list`, `schema describe` |
-| **Cloud SQL** | `instances list/get`, `databases list/get`, `schema describe` |
-| **Looker** | `instances list/get`, `explores list`, `dashboards get` |
+| **BigQuery** | `datasets list/get`, `tables list/get`, `jobs list/get/query`, `models list/get`, `routines list/get` |
+| **Spanner** | `instances list/get`, `databases list/get/get-ddl`, `backups list/get`, `schema describe` |
+| **AlloyDB** | `clusters list/get`, `instances list/get`, `backups list/get`, `users list/get`, `databases list`, `schema describe` |
+| **Cloud SQL** | `instances list/get`, `databases list/get`, `backupRuns list/get`, `users list/get`, `flags list`, `tiers list`, `schema describe` |
+| **Looker** | `instances list/get`, `backups list/get`, `explores list`, `dashboards get` |
 | **CA** | `ca ask`, `ca create-agent`, `ca list-agents`, `ca add-verified-query` |
 | **Auth** | `auth status`, `auth check` |
 | **Profiles** | `profiles list`, `profiles validate`, `profiles test` |

--- a/docs/go_mvp_plan.md
+++ b/docs/go_mvp_plan.md
@@ -717,7 +717,7 @@ The right message is:
 
 ## Implementation status
 
-All 6 phases are complete. The Go MVP is functional with 38 commands
+All 6 phases are complete. The Go MVP is functional with 58 commands
 across 10 domains, benchmarked at 5x faster than `bq`.
 
 | Phase | Status | PR |

--- a/internal/discovery/services.go
+++ b/internal/discovery/services.go
@@ -41,6 +41,8 @@ func SpannerConfig() *ServiceConfig {
 			"databases.list",
 			"databases.get",
 			"databases.getDdl",
+			"backups.list",
+			"backups.get",
 		},
 		GlobalParamMappings: map[string]string{},
 	}
@@ -61,6 +63,8 @@ func AlloyDBConfig() *ServiceConfig {
 			"instances.get",
 			"backups.list",
 			"backups.get",
+			"users.list",
+			"users.get",
 		},
 		GlobalParamMappings: map[string]string{},
 	}
@@ -80,6 +84,10 @@ func CloudSQLConfig() *ServiceConfig {
 			"databases.get",
 			"flags.list",
 			"tiers.list",
+			"backupRuns.list",
+			"backupRuns.get",
+			"users.list",
+			"users.get",
 		},
 		GlobalParamMappings: map[string]string{
 			"project": "project-id",
@@ -98,6 +106,8 @@ func LookerConfig() *ServiceConfig {
 		AllowedMethods: []string{
 			"instances.list",
 			"instances.get",
+			"backups.list",
+			"backups.get",
 		},
 		GlobalParamMappings: map[string]string{},
 	}

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -132,8 +132,8 @@ func TestCommandDiscovery(t *testing.T) {
 		}
 	}
 
-	if len(commands) < 48 {
-		t.Errorf("expected at least 48 commands, got %d", len(commands))
+	if len(commands) < 58 {
+		t.Errorf("expected at least 58 commands, got %d", len(commands))
 	}
 }
 


### PR DESCRIPTION
## Summary

10 new nested read commands (48 → 58 total). Consistent backup and user visibility across all data cloud services.

| Service | New commands | Nesting | Intermediate flags |
|---|---|---|---|
| **Spanner** | `backups list/get` | `instances/{instancesId}/backups` | `--instance-id` |
| **Looker** | `backups list/get` | `instances/{instancesId}/backups` | `--instance-id` |
| **AlloyDB** | `users list/get` | `clusters/{clustersId}/users` | `--cluster-id` |
| **CloudSQL** | `backupRuns list/get` | `instances/{instance}/backupRuns` | `--instance` (existing) |
| **CloudSQL** | `users list/get` | `instances/{instance}/users` | `--instance` (existing) |

Pagination flags are only added where the API supports them (`cloudsql users list` correctly omits them).

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes
- [x] All 10 new commands resolve paths correctly (AUTH_ERROR with fake token)
- [x] Pagination correctness verified per method via `meta describe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)