### PR TITLE
Expand read commands Tier 3: operations and instance configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An agent-native CLI for Google Cloud's Data Cloud, built in Go.
 One binary for BigQuery, Spanner, AlloyDB, Cloud SQL, and Looker —
 with structured output, typed errors, and an MCP bridge for AI agents.
 
-> **Status:** Go MVP functional — 58 commands across 10 domains.
+> **Status:** Go MVP functional — 65 commands across 10 domains.
 > Benchmarked at **5x faster** than `bq` with token cost within 6%.
 > See [docs/benchmark_results_bigquery.md](docs/benchmark_results_bigquery.md)
 > for measured results.
@@ -51,14 +51,14 @@ dcx ca ask "revenue by region this quarter" --agent=sales-agent --project-id=myp
 dcx mcp serve
 ```
 
-## Commands (58 total)
+## Commands (65 total)
 
 | Surface | Commands |
 |---|---|
 | **BigQuery** | `datasets list/get`, `tables list/get`, `jobs list/get/query`, `models list/get`, `routines list/get` |
-| **Spanner** | `instances list/get`, `databases list/get/get-ddl`, `backups list/get`, `schema describe` |
-| **AlloyDB** | `clusters list/get`, `instances list/get`, `backups list/get`, `users list/get`, `databases list`, `schema describe` |
-| **Cloud SQL** | `instances list/get`, `databases list/get`, `backupRuns list/get`, `users list/get`, `flags list`, `tiers list`, `schema describe` |
+| **Spanner** | `instances list/get`, `databases list/get/get-ddl`, `backups list/get`, `databaseOperations list`, `instanceConfigs list/get`, `schema describe` |
+| **AlloyDB** | `clusters list/get`, `instances list/get`, `backups list/get`, `users list/get`, `operations list/get`, `databases list`, `schema describe` |
+| **Cloud SQL** | `instances list/get`, `databases list/get`, `backupRuns list/get`, `users list/get`, `operations list/get`, `flags list`, `tiers list`, `schema describe` |
 | **Looker** | `instances list/get`, `backups list/get`, `explores list`, `dashboards get` |
 | **CA** | `ca ask`, `ca create-agent`, `ca list-agents`, `ca add-verified-query` |
 | **Auth** | `auth status`, `auth check` |

--- a/README.md
+++ b/README.md
@@ -144,11 +144,11 @@ dcx generates commands from bundled Google Cloud Discovery Documents
 
 | Service | Namespace | Discovery Doc | Commands |
 |---------|-----------|---------------|----------|
-| BigQuery | _(top-level)_ | `bigquery/v2` | datasets, tables |
-| Spanner | `spanner` | `spanner/v1` | instances, databases, getDdl |
-| AlloyDB | `alloydb` | `alloydb/v1` | clusters, instances |
-| Cloud SQL | `cloudsql` | `sqladmin/v1` | instances, databases |
-| Looker | `looker` | `looker/v1` | instances |
+| BigQuery | _(top-level)_ | `bigquery/v2` | datasets, tables, jobs, models, routines |
+| Spanner | `spanner` | `spanner/v1` | instances, databases, backups, databaseOperations, instanceConfigs |
+| AlloyDB | `alloydb` | `alloydb/v1` | clusters, instances, backups, users, operations |
+| Cloud SQL | `cloudsql` | `sqladmin/v1` | instances, databases, backupRuns, users, operations, flags, tiers |
+| Looker | `looker` | `looker/v1` | instances, backups |
 
 ### Contract System
 

--- a/docs/go_mvp_plan.md
+++ b/docs/go_mvp_plan.md
@@ -717,7 +717,7 @@ The right message is:
 
 ## Implementation status
 
-All 6 phases are complete. The Go MVP is functional with 58 commands
+All 6 phases are complete. The Go MVP is functional with 65 commands
 across 10 domains, benchmarked at 5x faster than `bq`.
 
 | Phase | Status | PR |

--- a/internal/discovery/services.go
+++ b/internal/discovery/services.go
@@ -43,6 +43,9 @@ func SpannerConfig() *ServiceConfig {
 			"databases.getDdl",
 			"backups.list",
 			"backups.get",
+			"databaseOperations.list",
+			"instanceConfigs.list",
+			"instanceConfigs.get",
 		},
 		GlobalParamMappings: map[string]string{},
 	}
@@ -65,6 +68,8 @@ func AlloyDBConfig() *ServiceConfig {
 			"backups.get",
 			"users.list",
 			"users.get",
+			"operations.list",
+			"operations.get",
 		},
 		GlobalParamMappings: map[string]string{},
 	}
@@ -88,6 +93,8 @@ func CloudSQLConfig() *ServiceConfig {
 			"backupRuns.get",
 			"users.list",
 			"users.get",
+			"operations.list",
+			"operations.get",
 		},
 		GlobalParamMappings: map[string]string{
 			"project": "project-id",

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -132,8 +132,8 @@ func TestCommandDiscovery(t *testing.T) {
 		}
 	}
 
-	if len(commands) < 58 {
-		t.Errorf("expected at least 58 commands, got %d", len(commands))
+	if len(commands) < 65 {
+		t.Errorf("expected at least 65 commands, got %d", len(commands))
 	}
 }
 

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -87,27 +87,40 @@ func TestCommandDiscovery(t *testing.T) {
 		t.Fatalf("parsing meta commands output: %v", err)
 	}
 
-	// All P0 commands must be present.
-	p0Commands := []string{
-		// BigQuery
+	// All shipped commands must be present.
+	requiredCommands := []string{
+		// BigQuery (Discovery + static)
 		"dcx datasets list", "dcx datasets get",
 		"dcx tables list", "dcx tables get",
-		"dcx jobs query",
+		"dcx jobs list", "dcx jobs get", "dcx jobs query",
+		"dcx models list", "dcx models get",
+		"dcx routines list", "dcx routines get",
 		// Spanner
 		"dcx spanner instances list", "dcx spanner instances get",
 		"dcx spanner databases list", "dcx spanner databases get",
 		"dcx spanner databases get-ddl", "dcx spanner schema describe",
+		"dcx spanner backups list", "dcx spanner backups get",
+		"dcx spanner database-operations list",
+		"dcx spanner instance-configs list", "dcx spanner instance-configs get",
 		// AlloyDB
 		"dcx alloydb clusters list", "dcx alloydb clusters get",
 		"dcx alloydb instances list", "dcx alloydb instances get",
 		"dcx alloydb databases list", "dcx alloydb schema describe",
+		"dcx alloydb backups list", "dcx alloydb backups get",
+		"dcx alloydb users list", "dcx alloydb users get",
+		"dcx alloydb operations list", "dcx alloydb operations get",
 		// Cloud SQL
 		"dcx cloudsql instances list", "dcx cloudsql instances get",
 		"dcx cloudsql databases list", "dcx cloudsql databases get",
 		"dcx cloudsql schema describe",
+		"dcx cloudsql backup-runs list", "dcx cloudsql backup-runs get",
+		"dcx cloudsql users list", "dcx cloudsql users get",
+		"dcx cloudsql operations list", "dcx cloudsql operations get",
+		"dcx cloudsql flags list", "dcx cloudsql tiers list",
 		// Looker
 		"dcx looker instances list", "dcx looker instances get",
 		"dcx looker explores list", "dcx looker dashboards get",
+		"dcx looker backups list", "dcx looker backups get",
 		// CA
 		"dcx ca ask",
 		"dcx ca create-agent", "dcx ca list-agents", "dcx ca add-verified-query",
@@ -126,7 +139,7 @@ func TestCommandDiscovery(t *testing.T) {
 		registered[c.Command] = true
 	}
 
-	for _, want := range p0Commands {
+	for _, want := range requiredCommands {
 		if !registered[want] {
 			t.Errorf("P0 command not registered: %s", want)
 		}


### PR DESCRIPTION
## Summary

7 new commands (58 → 65 total). Operational visibility across Spanner, AlloyDB, and CloudSQL.

| Service | New commands | Scope | Notes |
|---|---|---|---|
| **Spanner** | `databaseOperations list` | Instance-scoped | Track DDL/migration progress |
| **Spanner** | `instanceConfigs list/get` | Project-scoped | Available instance configurations |
| **AlloyDB** | `operations list/get` | Location-scoped | Track cluster/instance operations |
| **CloudSQL** | `operations list/get` | Project-scoped | Track instance operations |

Spanner `operations.list/get` is intentionally excluded — the Spanner Discovery doc has 6 different `operations` resources at different nesting levels, which would create command name collisions. Instead, `databaseOperations` (unique resource name) covers the most common use case.

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes
- [x] All 7 new commands resolve paths correctly
- [x] Docs updated (README 65 commands, plan doc updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)