### PR TITLE
Add BigQuery write operations: datasets and tables insert/delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An agent-native CLI for Google Cloud's Data Cloud, built in Go.
 One binary for BigQuery, Spanner, AlloyDB, Cloud SQL, and Looker —
 with structured output, typed errors, and an MCP bridge for AI agents.
 
-> **Status:** Go MVP functional — 66 commands across 11 domains.
+> **Status:** Go MVP functional — 70 commands across 11 domains.
 > Benchmarked at **5x faster** than `bq` with token cost within 6%.
 > See [docs/benchmark_results_bigquery.md](docs/benchmark_results_bigquery.md)
 > for measured results.
@@ -54,11 +54,11 @@ source <(dcx completion bash)
 dcx mcp serve
 ```
 
-## Commands (66 total)
+## Commands (70 total)
 
 | Surface | Commands |
 |---|---|
-| **BigQuery** | `datasets list/get`, `tables list/get`, `jobs list/get/query`, `models list/get`, `routines list/get` |
+| **BigQuery** | `datasets list/get/insert/delete`, `tables list/get/insert/delete`, `jobs list/get/query`, `models list/get`, `routines list/get` |
 | **Spanner** | `instances list/get`, `databases list/get/get-ddl`, `backups list/get`, `databaseOperations list`, `instanceConfigs list/get`, `schema describe` |
 | **AlloyDB** | `clusters list/get`, `instances list/get`, `backups list/get`, `users list/get`, `operations list/get`, `databases list`, `schema describe` |
 | **Cloud SQL** | `instances list/get`, `databases list/get`, `backupRuns list/get`, `users list/get`, `operations list/get`, `flags list`, `tiers list`, `schema describe` |
@@ -147,7 +147,7 @@ dcx generates commands from bundled Google Cloud Discovery Documents
 
 | Service | Namespace | Discovery Doc | Commands |
 |---------|-----------|---------------|----------|
-| BigQuery | _(top-level)_ | `bigquery/v2` | datasets, tables, jobs, models, routines |
+| BigQuery | _(top-level)_ | `bigquery/v2` | datasets (CRUD), tables (CRUD), jobs, models, routines |
 | Spanner | `spanner` | `spanner/v1` | instances, databases, backups, databaseOperations, instanceConfigs |
 | AlloyDB | `alloydb` | `alloydb/v1` | clusters, instances, backups, users, operations |
 | Cloud SQL | `cloudsql` | `sqladmin/v1` | instances, databases, backupRuns, users, operations, flags, tiers |

--- a/docs/go_mvp_plan.md
+++ b/docs/go_mvp_plan.md
@@ -717,7 +717,7 @@ The right message is:
 
 ## Implementation status
 
-All 6 phases are complete. The Go MVP is functional with 66 commands
+All 6 phases are complete. The Go MVP is functional with 70 commands
 across 11 domains, benchmarked at 5x faster than `bq`.
 
 | Phase | Status | PR |

--- a/docs/source-matrix.md
+++ b/docs/source-matrix.md
@@ -71,7 +71,7 @@ All commands support `--format json|json-minified|table|text`. Default is `json`
 
 ## Known Limitations
 
-- All source commands are read-only (no create/update/delete)
+- BigQuery datasets and tables support insert/delete; all other source commands are read-only
 - Schema describe uses CA QueryData — requires a valid profile
 - AlloyDB `--location` defaults to `-` (all locations), not `US`
 - Looker content commands use per-instance API, admin commands use GCP API

--- a/internal/discovery/parser_test.go
+++ b/internal/discovery/parser_test.go
@@ -18,8 +18,8 @@ func TestParseBigQueryDiscovery(t *testing.T) {
 		t.Fatalf("Parse: %v", err)
 	}
 
-	if len(commands) != 10 {
-		t.Errorf("expected 10 commands, got %d", len(commands))
+	if len(commands) != 14 {
+		t.Errorf("expected 14 commands, got %d", len(commands))
 		for _, cmd := range commands {
 			t.Logf("  %s", cmd.CommandPath)
 		}
@@ -32,7 +32,8 @@ func TestParseBigQueryDiscovery(t *testing.T) {
 	}
 
 	expected := []string{
-		"datasets list", "datasets get", "tables list", "tables get",
+		"datasets list", "datasets get", "datasets insert", "datasets delete",
+		"tables list", "tables get", "tables insert", "tables delete",
 		"jobs list", "jobs get", "models list", "models get",
 		"routines list", "routines get",
 	}

--- a/internal/discovery/register.go
+++ b/internal/discovery/register.go
@@ -85,6 +85,7 @@ func registerOneCommand(
 
 	// Build command-specific flags storage.
 	flagValues := make(map[string]*string, len(cmd.CommandFlags))
+	boolFlagValues := make(map[string]*bool)
 	pageToken := ""
 	pageAll := false
 	bodyFlag := ""
@@ -117,6 +118,11 @@ func registerOneCommand(
 					}
 				}
 			}
+			for name, val := range boolFlagValues {
+				if *val {
+					queryParams[name] = "true"
+				}
+			}
 			if pageToken != "" {
 				queryParams["pageToken"] = pageToken
 			}
@@ -143,12 +149,18 @@ func registerOneCommand(
 		},
 	}
 
-	// Register command-specific flags.
+	// Register command-specific flags with correct types.
 	for _, flag := range cmd.CommandFlags {
-		val := new(string)
-		flagValues[flag.Name] = val
 		flagName := camelToKebab(flag.Name)
-		leafCmd.Flags().StringVar(val, flagName, "", flag.Description)
+		if flag.Type == "boolean" {
+			val := new(bool)
+			boolFlagValues[flag.Name] = val
+			leafCmd.Flags().BoolVar(val, flagName, false, flag.Description)
+		} else {
+			val := new(string)
+			flagValues[flag.Name] = val
+			leafCmd.Flags().StringVar(val, flagName, "", flag.Description)
+		}
 	}
 
 	// Add pagination flags only for list commands whose API supports pagination.

--- a/internal/discovery/services.go
+++ b/internal/discovery/services.go
@@ -10,8 +10,12 @@ func BigQueryConfig() *ServiceConfig {
 		AllowedMethods: []string{
 			"datasets.list",
 			"datasets.get",
+			"datasets.insert",
+			"datasets.delete",
 			"tables.list",
 			"tables.get",
+			"tables.insert",
+			"tables.delete",
 			"jobs.list",
 			"jobs.get",
 			"models.list",

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -91,7 +91,9 @@ func TestCommandDiscovery(t *testing.T) {
 	requiredCommands := []string{
 		// BigQuery (Discovery + static)
 		"dcx datasets list", "dcx datasets get",
+		"dcx datasets insert", "dcx datasets delete",
 		"dcx tables list", "dcx tables get",
+		"dcx tables insert", "dcx tables delete",
 		"dcx jobs list", "dcx jobs get", "dcx jobs query",
 		"dcx models list", "dcx models get",
 		"dcx routines list", "dcx routines get",
@@ -147,8 +149,8 @@ func TestCommandDiscovery(t *testing.T) {
 		}
 	}
 
-	if len(commands) < 66 {
-		t.Errorf("expected at least 66 commands, got %d", len(commands))
+	if len(commands) < 70 {
+		t.Errorf("expected at least 70 commands, got %d", len(commands))
 	}
 }
 


### PR DESCRIPTION
## Summary

First mutation commands using the framework from PR #16. 4 new commands (66 → 70 total).

| Command | HTTP | Flags | Safety |
|---|---|---|---|
| `datasets insert` | POST | `--body` (required) | `--dry-run` shows URL + parsed body |
| `datasets delete` | DELETE | `--force` | TTY confirmation or `--force`; non-TTY fails closed |
| `tables insert` | POST | `--body` (required) | `--dry-run` shows URL + parsed body |
| `tables delete` | DELETE | `--force` | TTY confirmation or `--force`; non-TTY fails closed |

### Example

```bash
# Create dataset
dcx datasets insert --project-id=myproject \
  --body='{"datasetReference":{"datasetId":"sales"},"location":"US"}'

# Create table
dcx tables insert --project-id=myproject --dataset-id=sales \
  --body='{"tableReference":{"tableId":"orders"},"schema":{"fields":[{"name":"id","type":"INTEGER"}]}}'

# Preview what would be sent
dcx datasets delete --project-id=myproject --dataset-id=sales --dry-run

# Delete (non-interactive)
dcx tables delete --project-id=myproject --dataset-id=sales --table-id=orders --force
```

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes
- [x] Dry-run outputs correct method, URL, body, confirmation_required
- [x] Live E2E: create dataset → create table → verify schema → delete table → verify gone → delete dataset → verify gone
- [x] Contracts: `is_mutation=true`, `supports_dry_run=true`, `--body` on insert, `--force` on delete
- [x] Docs updated (70 commands, architecture table shows CRUD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)