### PR TITLE
Add spanner databases update-ddl with ergonomic --ddl/--ddl-file flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An agent-native CLI for Google Cloud's Data Cloud, built in Go.
 One binary for BigQuery, Spanner, AlloyDB, Cloud SQL, and Looker —
 with structured output, typed errors, and an MCP bridge for AI agents.
 
-> **Status:** Go MVP functional — 78 commands across 11 domains.
+> **Status:** Go MVP functional — 79 commands across 11 domains.
 > Benchmarked at **5x faster** than `bq` with token cost within 6%.
 > See [docs/benchmark_results_bigquery.md](docs/benchmark_results_bigquery.md)
 > for measured results.
@@ -54,12 +54,12 @@ source <(dcx completion bash)
 dcx mcp serve
 ```
 
-## Commands (78 total)
+## Commands (79 total)
 
 | Surface | Commands |
 |---|---|
 | **BigQuery** | `datasets list/get/insert/delete`, `tables list/get/insert/delete`, `jobs list/get/query`, `models list/get`, `routines list/get` |
-| **Spanner** | `instances list/get`, `databases list/get/get-ddl/create/drop-database`, `backups list/get/create/delete`, `databaseOperations list`, `instanceConfigs list/get`, `schema describe` |
+| **Spanner** | `instances list/get`, `databases list/get/get-ddl/create/drop-database/update-ddl`, `backups list/get/create/delete`, `databaseOperations list`, `instanceConfigs list/get`, `schema describe` |
 | **AlloyDB** | `clusters list/get`, `instances list/get`, `backups list/get`, `users list/get`, `operations list/get`, `databases list`, `schema describe` |
 | **Cloud SQL** | `instances list/get`, `databases list/get/insert/delete`, `backupRuns list/get`, `users list/get/insert/delete`, `operations list/get`, `flags list`, `tiers list`, `schema describe` |
 | **Looker** | `instances list/get`, `backups list/get`, `explores list`, `dashboards get` |

--- a/docs/go_mvp_plan.md
+++ b/docs/go_mvp_plan.md
@@ -717,7 +717,7 @@ The right message is:
 
 ## Implementation status
 
-All 6 phases are complete. The Go MVP is functional with 78 commands
+All 6 phases are complete. The Go MVP is functional with 79 commands
 across 11 domains, benchmarked at 5x faster than `bq`.
 
 | Phase | Status | PR |

--- a/docs/source-matrix.md
+++ b/docs/source-matrix.md
@@ -17,7 +17,7 @@ Cross-source command matrix for dcx v0.5.0.
 | `clusters list\|get` | — | — | Yes | — | — |
 | `databases list\|get` | — | Yes | — | Yes | — |
 | `databases insert\|delete` | — | — | — | Yes | — |
-| `databases create\|drop-database` | — | Yes | — | — | — |
+| `databases create\|drop-database\|update-ddl` | — | Yes | — | — | — |
 | `databases get-ddl` | — | Yes | — | — | — |
 | `backups list\|get` | — | Yes | Yes | — | Yes |
 | `backups create\|delete` | — | Yes | — | — | — |

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -85,6 +85,9 @@ Structured output, typed errors, and an MCP bridge for AI agents.`,
 	// Register CA commands.
 	app.addCACommands()
 
+	// Register static Spanner commands (update-ddl with ergonomic flags).
+	app.registerSpannerUpdateDdlCommand()
+
 	// Register Data Cloud helper commands (schema describe, databases list via QueryData).
 	app.registerDataCloudHelperCommands()
 

--- a/internal/cli/spanner_ddl.go
+++ b/internal/cli/spanner_ddl.go
@@ -44,6 +44,7 @@ func (a *App) registerSpannerUpdateDdlCommand() {
 	var ddlStatements []string
 	var ddlFile string
 	var instanceID, databaseID string
+	var operationID, protoDescriptors string
 
 	cmd := &cobra.Command{
 		Use:   "update-ddl",
@@ -99,6 +100,12 @@ Examples:
 			apiURL := fmt.Sprintf(spannerDDLEndpoint, projectID, instanceID, databaseID)
 			body := map[string]interface{}{
 				"statements": statements,
+			}
+			if operationID != "" {
+				body["operationId"] = operationID
+			}
+			if protoDescriptors != "" {
+				body["protoDescriptors"] = protoDescriptors
 			}
 			bodyJSON, _ := json.Marshal(body)
 
@@ -174,6 +181,8 @@ Examples:
 	cmd.Flags().StringVar(&ddlFile, "ddl-file", "", "Path to file with semicolon-delimited DDL statements")
 	cmd.Flags().StringVar(&instanceID, "instance-id", "", "Spanner instance ID (required)")
 	cmd.Flags().StringVar(&databaseID, "database-id", "", "Spanner database ID (required)")
+	cmd.Flags().StringVar(&operationID, "operation-id", "", "Caller-supplied operation ID for idempotent retries")
+	cmd.Flags().StringVar(&protoDescriptors, "proto-descriptors", "", "Base64-encoded proto descriptors for CREATE/ALTER PROTO BUNDLE")
 
 	dbsCmd.AddCommand(cmd)
 
@@ -185,6 +194,8 @@ Examples:
 			{Name: "ddl-file", Type: "string", Description: "Path to file with semicolon-delimited DDL statements"},
 			{Name: "instance-id", Type: "string", Description: "Spanner instance ID", Required: true},
 			{Name: "database-id", Type: "string", Description: "Spanner database ID", Required: true},
+			{Name: "operation-id", Type: "string", Description: "Caller-supplied operation ID for idempotent retries"},
+			{Name: "proto-descriptors", Type: "string", Description: "Base64-encoded proto descriptors for CREATE/ALTER PROTO BUNDLE"},
 		},
 		true, true,
 	))

--- a/internal/cli/spanner_ddl.go
+++ b/internal/cli/spanner_ddl.go
@@ -1,0 +1,220 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/haiyuan-eng-google/dcx-cli/internal/auth"
+	"github.com/haiyuan-eng-google/dcx-cli/internal/contracts"
+	dcxerrors "github.com/haiyuan-eng-google/dcx-cli/internal/errors"
+	"github.com/haiyuan-eng-google/dcx-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+const spannerDDLEndpoint = "https://spanner.googleapis.com/v1/projects/%s/instances/%s/databases/%s/ddl"
+
+func (a *App) registerSpannerUpdateDdlCommand() {
+	// Find or create the spanner -> databases group.
+	var spannerCmd, dbsCmd *cobra.Command
+	for _, child := range a.Root.Commands() {
+		if child.Name() == "spanner" {
+			spannerCmd = child
+			break
+		}
+	}
+	if spannerCmd == nil {
+		return // Spanner not registered yet
+	}
+	for _, child := range spannerCmd.Commands() {
+		if child.Name() == "databases" {
+			dbsCmd = child
+			break
+		}
+	}
+	if dbsCmd == nil {
+		return // databases group not registered yet
+	}
+
+	var ddlStatements []string
+	var ddlFile string
+	var instanceID, databaseID string
+
+	cmd := &cobra.Command{
+		Use:   "update-ddl",
+		Short: "Apply DDL statements to a Spanner database",
+		Long: `Apply one or more DDL statements (CREATE TABLE, ALTER TABLE, etc.)
+to a Cloud Spanner database. Returns a long-running operation.
+
+Examples:
+  # Single statement
+  dcx spanner databases update-ddl --instance-id=myinst --database-id=mydb \
+    --ddl "CREATE TABLE users (id INT64, name STRING(100)) PRIMARY KEY (id)"
+
+  # Multiple statements
+  dcx spanner databases update-ddl --instance-id=myinst --database-id=mydb \
+    --ddl "CREATE TABLE t1 (id INT64) PRIMARY KEY (id)" \
+    --ddl "CREATE INDEX idx ON t1 (id)"
+
+  # From file (semicolon-delimited)
+  dcx spanner databases update-ddl --instance-id=myinst --database-id=mydb \
+    --ddl-file schema.sql`,
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			format, err := a.OutputFormat()
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.InvalidConfig, err.Error(), "")
+				return nil
+			}
+
+			projectID := a.Opts.ProjectID
+			if projectID == "" {
+				dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --project-id is missing", "")
+				return nil
+			}
+			if instanceID == "" {
+				dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --instance-id is missing", "")
+				return nil
+			}
+			if databaseID == "" {
+				dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --database-id is missing", "")
+				return nil
+			}
+
+			// Collect DDL statements from flags and/or file.
+			statements, err := collectDDLStatements(ddlStatements, ddlFile)
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.InvalidConfig, err.Error(), "")
+				return nil
+			}
+			if len(statements) == 0 {
+				dcxerrors.Emit(dcxerrors.MissingArgument, "at least one DDL statement is required", "Use --ddl or --ddl-file")
+				return nil
+			}
+
+			apiURL := fmt.Sprintf(spannerDDLEndpoint, projectID, instanceID, databaseID)
+			body := map[string]interface{}{
+				"statements": statements,
+			}
+			bodyJSON, _ := json.Marshal(body)
+
+			// Dry-run: show what would be sent.
+			if a.Opts.DryRun {
+				return output.Render(format, map[string]interface{}{
+					"method":                "PATCH",
+					"url":                   apiURL,
+					"body":                  body,
+					"body_schema":           "UpdateDatabaseDdlRequest",
+					"statement_count":       len(statements),
+					"confirmation_required": false,
+				})
+			}
+
+			// Resolve auth.
+			ctx := context.Background()
+			resolved, err := auth.Resolve(ctx, a.AuthConfig())
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.AuthError, err.Error(), "")
+				return nil
+			}
+			tok, err := resolved.TokenSource.Token()
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.AuthError, fmt.Sprintf("failed to obtain token: %v", err), "")
+				return nil
+			}
+
+			// Execute request.
+			req, err := http.NewRequestWithContext(ctx, "PATCH", apiURL, bytes.NewReader(bodyJSON))
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.Internal, err.Error(), "")
+				return nil
+			}
+			req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.InfraError, fmt.Sprintf("API request failed: %v", err), "")
+				return nil
+			}
+			defer resp.Body.Close()
+
+			respBody, _ := io.ReadAll(resp.Body)
+
+			if resp.StatusCode >= 400 {
+				var apiErr struct {
+					Error struct {
+						Message string `json:"message"`
+					} `json:"error"`
+				}
+				message := fmt.Sprintf("API returned HTTP %d", resp.StatusCode)
+				if json.Unmarshal(respBody, &apiErr) == nil && apiErr.Error.Message != "" {
+					message = apiErr.Error.Message
+				}
+				code := dcxerrors.ErrorCodeFromHTTP(resp.StatusCode)
+				dcxerrors.Emit(code, message, "")
+				return nil
+			}
+
+			var raw map[string]interface{}
+			if err := json.Unmarshal(respBody, &raw); err != nil {
+				dcxerrors.Emit(dcxerrors.Internal, fmt.Sprintf("parsing response: %v", err), "")
+				return nil
+			}
+
+			return output.Render(format, raw)
+		},
+	}
+
+	cmd.Flags().StringArrayVar(&ddlStatements, "ddl", nil, "DDL statement (can be repeated)")
+	cmd.Flags().StringVar(&ddlFile, "ddl-file", "", "Path to file with semicolon-delimited DDL statements")
+	cmd.Flags().StringVar(&instanceID, "instance-id", "", "Spanner instance ID (required)")
+	cmd.Flags().StringVar(&databaseID, "database-id", "", "Spanner database ID (required)")
+
+	dbsCmd.AddCommand(cmd)
+
+	a.Registry.Register(contracts.BuildContract(
+		"spanner databases update-ddl", "spanner",
+		"Apply DDL statements to a Spanner database",
+		[]contracts.FlagContract{
+			{Name: "ddl", Type: "string", Description: "DDL statement (can be repeated)"},
+			{Name: "ddl-file", Type: "string", Description: "Path to file with semicolon-delimited DDL statements"},
+			{Name: "instance-id", Type: "string", Description: "Spanner instance ID", Required: true},
+			{Name: "database-id", Type: "string", Description: "Spanner database ID", Required: true},
+		},
+		true, true,
+	))
+}
+
+// collectDDLStatements gathers DDL statements from --ddl flags and/or --ddl-file.
+func collectDDLStatements(flags []string, filePath string) ([]string, error) {
+	var statements []string
+
+	// From --ddl flags.
+	for _, s := range flags {
+		trimmed := strings.TrimSpace(s)
+		if trimmed != "" {
+			statements = append(statements, trimmed)
+		}
+	}
+
+	// From --ddl-file.
+	if filePath != "" {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("reading DDL file %s: %w", filePath, err)
+		}
+		for _, stmt := range strings.Split(string(data), ";") {
+			trimmed := strings.TrimSpace(stmt)
+			if trimmed != "" {
+				statements = append(statements, trimmed)
+			}
+		}
+	}
+
+	return statements, nil
+}

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -102,6 +102,7 @@ func TestCommandDiscovery(t *testing.T) {
 		"dcx spanner databases list", "dcx spanner databases get",
 		"dcx spanner databases get-ddl", "dcx spanner schema describe",
 		"dcx spanner databases create", "dcx spanner databases drop-database",
+		"dcx spanner databases update-ddl",
 		"dcx spanner backups list", "dcx spanner backups get",
 		"dcx spanner backups create", "dcx spanner backups delete",
 		"dcx spanner database-operations list",
@@ -153,8 +154,8 @@ func TestCommandDiscovery(t *testing.T) {
 		}
 	}
 
-	if len(commands) < 78 {
-		t.Errorf("expected at least 78 commands, got %d", len(commands))
+	if len(commands) < 79 {
+		t.Errorf("expected at least 79 commands, got %d", len(commands))
 	}
 }
 


### PR DESCRIPTION
## Summary

Static command for Spanner DDL migrations with developer-friendly flags (78 → 79 commands).

### Why static (not Discovery-driven)

The raw API takes `{"statements": ["CREATE TABLE ...", ...]}` via `--body`, which is functional but poor UX for the most common Spanner workflow. This command provides ergonomic alternatives while keeping the same mutation safety model.

### Usage

```bash
# Single statement
dcx spanner databases update-ddl --project-id=myproject --instance-id=myinst \
  --database-id=mydb --ddl "CREATE TABLE users (id INT64) PRIMARY KEY (id)"

# Multiple statements (--ddl can be repeated)
dcx spanner databases update-ddl --instance-id=myinst --database-id=mydb \
  --ddl "CREATE TABLE t1 (id INT64) PRIMARY KEY (id)" \
  --ddl "CREATE INDEX idx ON t1 (id)"

# From semicolon-delimited file
dcx spanner databases update-ddl --instance-id=myinst --database-id=mydb \
  --ddl-file schema.sql

# Preview
dcx spanner databases update-ddl --instance-id=myinst --database-id=mydb \
  --ddl "ALTER TABLE t1 ADD COLUMN name STRING(100)" --dry-run
```

### Design

| Flag | Description |
|---|---|
| `--ddl` | DDL statement string, can be repeated for multiple |
| `--ddl-file` | Path to semicolon-delimited SQL file |
| `--instance-id` | Required |
| `--database-id` | Required |
| `--dry-run` | Shows method, URL, statements, count — skips API call |

Contract: `is_mutation=true`, `supports_dry_run=true`.

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes
- [x] `--ddl` single and multiple statements
- [x] `--ddl-file` parses 3 semicolon-delimited statements from file
- [x] `--dry-run` renders correct method, URL, body, statement_count
- [x] Live E2E: applied CREATE TABLE + CREATE INDEX, verified with get-ddl
- [x] Docs updated (79 commands, source-matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)