### PR TITLE
Add AlloyDB users create/delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An agent-native CLI for Google Cloud's Data Cloud, built in Go.
 One binary for BigQuery, Spanner, AlloyDB, Cloud SQL, and Looker —
 with structured output, typed errors, and an MCP bridge for AI agents.
 
-> **Status:** Go MVP functional — 79 commands across 11 domains.
+> **Status:** Go MVP functional — 81 commands across 11 domains.
 > Benchmarked at **5x faster** than `bq` with token cost within 6%.
 > See [docs/benchmark_results_bigquery.md](docs/benchmark_results_bigquery.md)
 > for measured results.
@@ -54,13 +54,13 @@ source <(dcx completion bash)
 dcx mcp serve
 ```
 
-## Commands (79 total)
+## Commands (81 total)
 
 | Surface | Commands |
 |---|---|
 | **BigQuery** | `datasets list/get/insert/delete`, `tables list/get/insert/delete`, `jobs list/get/query`, `models list/get`, `routines list/get` |
 | **Spanner** | `instances list/get`, `databases list/get/get-ddl/create/drop-database/update-ddl`, `backups list/get/create/delete`, `databaseOperations list`, `instanceConfigs list/get`, `schema describe` |
-| **AlloyDB** | `clusters list/get`, `instances list/get`, `backups list/get`, `users list/get`, `operations list/get`, `databases list`, `schema describe` |
+| **AlloyDB** | `clusters list/get`, `instances list/get`, `backups list/get`, `users list/get/create/delete`, `operations list/get`, `databases list`, `schema describe` |
 | **Cloud SQL** | `instances list/get`, `databases list/get/insert/delete`, `backupRuns list/get`, `users list/get/insert/delete`, `operations list/get`, `flags list`, `tiers list`, `schema describe` |
 | **Looker** | `instances list/get`, `backups list/get`, `explores list`, `dashboards get` |
 | **CA** | `ca ask`, `ca create-agent`, `ca list-agents`, `ca add-verified-query` |
@@ -149,7 +149,7 @@ dcx generates commands from bundled Google Cloud Discovery Documents
 |---------|-----------|---------------|----------|
 | BigQuery | _(top-level)_ | `bigquery/v2` | datasets (CRUD), tables (CRUD), jobs, models, routines |
 | Spanner | `spanner` | `spanner/v1` | instances, databases (CRUD), backups (CRUD), databaseOperations, instanceConfigs |
-| AlloyDB | `alloydb` | `alloydb/v1` | clusters, instances, backups, users, operations |
+| AlloyDB | `alloydb` | `alloydb/v1` | clusters, instances, backups, users (CRUD), operations |
 | Cloud SQL | `cloudsql` | `sqladmin/v1` | instances, databases (CRUD), backupRuns, users (CRUD), operations, flags, tiers |
 | Looker | `looker` | `looker/v1` | instances, backups |
 

--- a/docs/go_mvp_plan.md
+++ b/docs/go_mvp_plan.md
@@ -717,7 +717,7 @@ The right message is:
 
 ## Implementation status
 
-All 6 phases are complete. The Go MVP is functional with 79 commands
+All 6 phases are complete. The Go MVP is functional with 81 commands
 across 11 domains, benchmarked at 5x faster than `bq`.
 
 | Phase | Status | PR |

--- a/docs/source-matrix.md
+++ b/docs/source-matrix.md
@@ -23,6 +23,7 @@ Cross-source command matrix for dcx v0.5.0.
 | `backups create\|delete` | — | Yes | — | — | — |
 | `backupRuns list\|get` | — | — | — | Yes | — |
 | `users list\|get` | — | — | Yes | Yes | — |
+| `users create\|delete` | — | — | Yes | Yes | — |
 | `users insert\|delete` | — | — | — | Yes | — |
 | `operations list\|get` | — | — | Yes | Yes | — |
 | `databaseOperations list` | — | Yes | — | — | — |
@@ -82,7 +83,7 @@ All commands support `--format json|json-minified|table|text`. Default is `json`
 
 ## Known Limitations
 
-- BigQuery datasets/tables, Cloud SQL databases/users, and Spanner databases/backups support write operations; all other source commands are read-only
+- BigQuery datasets/tables, Cloud SQL databases/users, Spanner databases/backups, and AlloyDB users support write operations; all other source commands are read-only
 - Schema describe uses CA QueryData — requires a valid profile
 - AlloyDB `--location` defaults to `-` (all locations), not `US`
 - Looker content commands use per-instance API, admin commands use GCP API

--- a/internal/discovery/services.go
+++ b/internal/discovery/services.go
@@ -76,6 +76,8 @@ func AlloyDBConfig() *ServiceConfig {
 			"backups.get",
 			"users.list",
 			"users.get",
+			"users.create",
+			"users.delete",
 			"operations.list",
 			"operations.get",
 		},

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -113,6 +113,7 @@ func TestCommandDiscovery(t *testing.T) {
 		"dcx alloydb databases list", "dcx alloydb schema describe",
 		"dcx alloydb backups list", "dcx alloydb backups get",
 		"dcx alloydb users list", "dcx alloydb users get",
+		"dcx alloydb users create", "dcx alloydb users delete",
 		"dcx alloydb operations list", "dcx alloydb operations get",
 		// Cloud SQL
 		"dcx cloudsql instances list", "dcx cloudsql instances get",
@@ -154,8 +155,8 @@ func TestCommandDiscovery(t *testing.T) {
 		}
 	}
 
-	if len(commands) < 79 {
-		t.Errorf("expected at least 79 commands, got %d", len(commands))
+	if len(commands) < 81 {
+		t.Errorf("expected at least 81 commands, got %d", len(commands))
 	}
 }
 


### PR DESCRIPTION
## Summary

2 new AlloyDB mutation commands (79 → 81 total). Completes the write operations sequence across all data cloud services.

| Command | HTTP | Key flags | Response |
|---|---|---|---|
| `alloydb users create` | POST | `--cluster-id`, `--user-id`, `--body` | User (direct) |
| `alloydb users delete` | DELETE | `--cluster-id`, `--user-id`, `--force` | Empty |

Both also expose `--validate-only` (bool) and `--request-id` (string) from the Discovery doc.

### Write ops complete

| Service | Write commands |
|---|---|
| BigQuery | datasets insert/delete, tables insert/delete |
| Cloud SQL | databases insert/delete, users insert/delete |
| Spanner | databases create/drop-database/update-ddl, backups create/delete |
| AlloyDB | users create/delete |

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes
- [x] Dry-run outputs correct method, URL, body for both commands
- [x] Contracts: `is_mutation=true`, correct flags including `validate-only` as bool
- [x] Docs updated (81 commands, source-matrix, architecture table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)