### PR TITLE
Update benchmarks and docs for 81-command surface

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,6 @@
 # dcx CLI Benchmark Suite
 
-Systematic benchmark comparing `dcx` against `bq` and `gcloud spanner` CLIs.
+Systematic benchmark comparing `dcx` against `bq`, `gcloud spanner`, and `gcloud sql` CLIs.
 
 > **Carried over from [bqx-cli](https://github.com/haiyuan-eng-google/bqx-cli).**
 > Task specs, runner, and scorer are ready to use. The benchmark suite
@@ -68,8 +68,9 @@ python3 scripts/score_results.py results/raw/<run-id>
 benchmarks/
   manifest.yaml              # Environment bindings ({project}, {dataset}, etc.)
   tasks/
-    bigquery_overlap.yaml     # 12 BigQuery parity tasks
-    spanner_overlap.yaml      # 11 Spanner parity tasks
+    bigquery_overlap.yaml     # 17 BigQuery parity tasks (reads + mutations dry-run)
+    spanner_overlap.yaml      # 15 Spanner parity tasks (reads + DDL dry-run)
+    cloudsql_overlap.yaml     #  4 Cloud SQL parity tasks
     dcx_differentiated.yaml   #  8 dcx-only differentiated tasks
   data/
     bigquery/seed.sql         # BigQuery seed data (Tier D private tables)
@@ -98,8 +99,9 @@ benchmarks/
 
 | Track | Tasks | CLIs Compared |
 |-------|-------|---------------|
-| BigQuery parity | 12 | dcx vs bq |
-| Spanner parity | 11 | dcx vs gcloud spanner |
+| BigQuery parity | 17 | dcx vs bq |
+| Spanner parity | 15 | dcx vs gcloud spanner |
+| Cloud SQL parity | 4 | dcx vs gcloud sql |
 | dcx differentiated | 8 | dcx only |
 
 See the task YAML files for full specifications.

--- a/benchmarks/manifest.yaml
+++ b/benchmarks/manifest.yaml
@@ -38,6 +38,14 @@ spanner_database: "bench-music"
 spanner_nonexistent_instance: "does-not-exist-instance-xyz"
 spanner_nonexistent_database: "does-not-exist-db-xyz"
 
+# ── Cloud SQL ────────────────────────────────────────────────────
+cloudsql_instance: "dcx-bench"
+cloudsql_database: "bench-db"
+
+# ── AlloyDB ─────────────────────────────────────────────────────
+alloydb_cluster: "dcx-bench"
+alloydb_location: "us-central1"
+
 # ── Profiles ─────────────────────────────────────────────────────────
 # Profile name for the dcx-profiles-test differentiated task.
 # Create ~/.config/dcx/profiles/bench.yaml (see benchmarks/README.md § Seed Data)

--- a/benchmarks/scripts/run_benchmarks.sh
+++ b/benchmarks/scripts/run_benchmarks.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Run the benchmark suite.
 #
-# Usage: ./run_benchmarks.sh [--tasks bigquery_overlap|spanner_overlap|dcx_differentiated] [--trials N]
+# Usage: ./run_benchmarks.sh [--tasks bigquery_overlap|spanner_overlap|cloudsql_overlap|dcx_differentiated] [--trials N]
 #
 # Reads task specs from tasks/*.yaml, resolves placeholders from manifest.yaml,
 # executes each CLI variant, and writes raw results to results/raw/.

--- a/benchmarks/tasks/bigquery_overlap.yaml
+++ b/benchmarks/tasks/bigquery_overlap.yaml
@@ -141,6 +141,109 @@ tasks:
           type: json_parse
     metrics: *standard_metrics
 
+  - id: bq-job-list
+    track: parity
+    system: bigquery
+    dataset_tier: small
+    goal: List recent jobs in the project
+    cli_variants:
+      - name: dcx
+        command: >-
+          dcx jobs list
+          --project-id {project}
+          --format json
+        validation:
+          type: json_keys
+          expected_keys: [items, source]
+      - name: bq
+        command: >-
+          bq ls -j --format=json --project_id={project}
+        validation:
+          type: json_parse
+    metrics: *standard_metrics
+
+  - id: bq-model-list
+    track: parity
+    system: bigquery
+    dataset_tier: small
+    goal: List models in a dataset
+    cli_variants:
+      - name: dcx
+        command: >-
+          dcx models list
+          --project-id {project}
+          --dataset-id {bq_benchmark_dataset}
+          --format json
+        validation:
+          type: json_keys
+          expected_keys: [items, source]
+      - name: bq
+        command: >-
+          bq ls --format=json --model {project}:{bq_benchmark_dataset}
+        validation:
+          type: json_parse
+    metrics: *standard_metrics
+
+  - id: bq-routine-list
+    track: parity
+    system: bigquery
+    dataset_tier: small
+    goal: List routines in a dataset
+    cli_variants:
+      - name: dcx
+        command: >-
+          dcx routines list
+          --project-id {project}
+          --dataset-id {bq_benchmark_dataset}
+          --format json
+        validation:
+          type: json_keys
+          expected_keys: [items, source]
+      - name: bq
+        command: >-
+          bq ls --format=json --routine {project}:{bq_benchmark_dataset}
+        validation:
+          type: json_parse
+    metrics: *standard_metrics
+
+  # ── Mutation dry-run tasks ──────────────────────────────────────────
+
+  - id: bq-dataset-insert-dryrun
+    track: parity
+    system: bigquery
+    dataset_tier: small
+    goal: Dry-run dataset creation to validate body and URL
+    cli_variants:
+      - name: dcx
+        command: >-
+          dcx datasets insert
+          --project-id {project}
+          --body '{"datasetReference":{"datasetId":"dryrun_test"},"location":"US"}'
+          --dry-run
+          --format json
+        validation:
+          type: json_keys
+          expected_keys: [method, url, body]
+    metrics: *standard_metrics
+
+  - id: bq-dataset-delete-dryrun
+    track: parity
+    system: bigquery
+    dataset_tier: small
+    goal: Dry-run dataset deletion to validate URL and confirmation
+    cli_variants:
+      - name: dcx
+        command: >-
+          dcx datasets delete
+          --project-id {project}
+          --dataset-id {bq_nonexistent_dataset}
+          --dry-run
+          --format json
+        validation:
+          type: json_keys
+          expected_keys: [method, url, confirmation_required]
+    metrics: *standard_metrics
+
   # ── Query tasks ──────────────────────────────────────────────────────
 
   - id: bq-dryrun-aggregate

--- a/benchmarks/tasks/cloudsql_overlap.yaml
+++ b/benchmarks/tasks/cloudsql_overlap.yaml
@@ -1,0 +1,105 @@
+# Cloud SQL parity tasks — dcx vs gcloud sql CLI.
+#
+# Placeholders like {project} are resolved from manifest.yaml at runtime.
+
+tasks:
+  # ── Read tasks ───────────────────────────────────────────────────────
+
+  - id: csql-instance-list
+    track: parity
+    system: cloudsql
+    dataset_tier: small
+    goal: List Cloud SQL instances in the project
+    cli_variants:
+      - name: dcx
+        command: >-
+          dcx cloudsql instances list
+          --project-id {project}
+          --format json
+        validation:
+          type: json_keys
+          expected_keys: [items, source]
+      - name: gcloud
+        command: >-
+          gcloud sql instances list
+          --project={project}
+          --format=json
+        validation:
+          type: json_parse
+    metrics: &standard_metrics
+      - exit_code
+      - wall_clock_ms
+      - stdout_bytes
+      - stderr_bytes
+      - token_input_estimate
+      - token_output_estimate
+
+  - id: csql-flags-list
+    track: parity
+    system: cloudsql
+    dataset_tier: small
+    goal: List available Cloud SQL flags
+    cli_variants:
+      - name: dcx
+        command: >-
+          dcx cloudsql flags list
+          --format json
+        validation:
+          type: json_keys
+          expected_keys: [items, source]
+      - name: gcloud
+        command: >-
+          gcloud sql flags list
+          --format=json
+        validation:
+          type: json_parse
+    metrics: *standard_metrics
+
+  - id: csql-tiers-list
+    track: parity
+    system: cloudsql
+    dataset_tier: small
+    goal: List available Cloud SQL tiers
+    cli_variants:
+      - name: dcx
+        command: >-
+          dcx cloudsql tiers list
+          --project-id {project}
+          --format json
+        validation:
+          type: json_keys
+          expected_keys: [items, source]
+      - name: gcloud
+        command: >-
+          gcloud sql tiers list
+          --project={project}
+          --format=json
+        validation:
+          type: json_parse
+    metrics: *standard_metrics
+
+  - id: csql-operations-list
+    track: parity
+    system: cloudsql
+    dataset_tier: small
+    goal: List Cloud SQL operations
+    note: >-
+      Requires a Cloud SQL instance to exist. The --instance flag is
+      required by the API even though the Discovery doc marks it optional.
+    cli_variants:
+      - name: dcx
+        command: >-
+          dcx cloudsql operations list
+          --project-id {project}
+          --format json
+        validation:
+          type: json_keys
+          expected_keys: [items, source]
+      - name: gcloud
+        command: >-
+          gcloud sql operations list
+          --project={project}
+          --format=json
+        validation:
+          type: json_parse
+    metrics: *standard_metrics

--- a/benchmarks/tasks/cloudsql_overlap.yaml
+++ b/benchmarks/tasks/cloudsql_overlap.yaml
@@ -82,15 +82,16 @@ tasks:
     track: parity
     system: cloudsql
     dataset_tier: small
-    goal: List Cloud SQL operations
+    goal: List Cloud SQL operations for an instance
     note: >-
-      Requires a Cloud SQL instance to exist. The --instance flag is
-      required by the API even though the Discovery doc marks it optional.
+      The Cloud SQL API requires --instance even though the Discovery
+      doc marks it optional. Both variants pass --instance.
     cli_variants:
       - name: dcx
         command: >-
           dcx cloudsql operations list
           --project-id {project}
+          --instance {cloudsql_instance}
           --format json
         validation:
           type: json_keys
@@ -98,6 +99,7 @@ tasks:
       - name: gcloud
         command: >-
           gcloud sql operations list
+          --instance={cloudsql_instance}
           --project={project}
           --format=json
         validation:

--- a/benchmarks/tasks/dcx_differentiated.yaml
+++ b/benchmarks/tasks/dcx_differentiated.yaml
@@ -32,7 +32,7 @@ tasks:
     cli_variants:
       - name: dcx
         command: >-
-          dcx meta describe analytics evaluate --format json
+          dcx meta describe spanner databases update-ddl --format json
     validation:
       type: json_keys
       expected_keys: [contract_version, command, flags, exit_codes]

--- a/benchmarks/tasks/spanner_overlap.yaml
+++ b/benchmarks/tasks/spanner_overlap.yaml
@@ -115,6 +115,99 @@ tasks:
           type: json_parse
     metrics: *standard_metrics
 
+  - id: sp-backup-list
+    track: parity
+    system: spanner
+    dataset_tier: small
+    goal: List backups for a Spanner instance
+    cli_variants:
+      - name: dcx
+        command: >-
+          dcx spanner backups list
+          --project-id {project}
+          --instance-id {spanner_instance}
+          --format json
+        validation:
+          type: json_keys
+          expected_keys: [items, source]
+      - name: gcloud
+        command: >-
+          gcloud spanner backups list
+          --instance={spanner_instance}
+          --project={project}
+          --format=json
+        validation:
+          type: json_parse
+    metrics: *standard_metrics
+
+  - id: sp-instance-configs-list
+    track: parity
+    system: spanner
+    dataset_tier: small
+    goal: List available Spanner instance configurations
+    cli_variants:
+      - name: dcx
+        command: >-
+          dcx spanner instance-configs list
+          --project-id {project}
+          --format json
+        validation:
+          type: json_keys
+          expected_keys: [items, source]
+      - name: gcloud
+        command: >-
+          gcloud spanner instance-configs list
+          --project={project}
+          --format=json
+        validation:
+          type: json_parse
+    metrics: *standard_metrics
+
+  - id: sp-database-operations-list
+    track: parity
+    system: spanner
+    dataset_tier: small
+    goal: List database operations for a Spanner instance
+    cli_variants:
+      - name: dcx
+        command: >-
+          dcx spanner database-operations list
+          --project-id {project}
+          --instance-id {spanner_instance}
+          --format json
+        validation:
+          type: json_keys
+          expected_keys: [items, source]
+      - name: gcloud
+        command: >-
+          gcloud spanner operations list
+          --instance={spanner_instance}
+          --project={project}
+          --format=json
+        validation:
+          type: json_parse
+    metrics: *standard_metrics
+
+  - id: sp-update-ddl-dryrun
+    track: differentiated
+    system: spanner
+    dataset_tier: small
+    goal: Dry-run DDL update to validate statements and URL
+    cli_variants:
+      - name: dcx
+        command: >-
+          dcx spanner databases update-ddl
+          --project-id {project}
+          --instance-id {spanner_instance}
+          --database-id {spanner_database}
+          --ddl "CREATE TABLE bench_test (id INT64) PRIMARY KEY (id)"
+          --dry-run
+          --format json
+        validation:
+          type: json_keys
+          expected_keys: [method, url, body]
+    metrics: *standard_metrics
+
   # ── SQL tasks (baseline-only, dcx N/A) ──────────────────────────────
 
   - id: sp-query-simple

--- a/docs/benchmark_results_bigquery.md
+++ b/docs/benchmark_results_bigquery.md
@@ -198,6 +198,25 @@ This benchmark measures a specific, narrow slice:
 The results are directionally strong but should be validated on Linux CI
 hosts and with higher trial counts before quoting in external materials.
 
+### Expanded Surface (not yet benchmarked)
+
+Since the original 12-task benchmark was run, dcx has grown from 38 to 81
+commands. The following surfaces have benchmark task definitions but have
+not yet been measured:
+
+| Surface | New tasks | Commands |
+|---|---|---|
+| **BigQuery** | jobs list, models list, routines list, mutation dry-runs | 9 new commands (jobs list/get, models list/get, routines list/get, datasets insert/delete, tables insert/delete) |
+| **Spanner** | backups list, instance-configs list, database-operations list, update-ddl dry-run | 10 new commands (databases create/drop/update-ddl, backups list/get/create/delete, databaseOperations list, instanceConfigs list/get) |
+| **Cloud SQL** | instances list, flags list, tiers list, operations list | 17 commands total (CRUD for databases + users, backupRuns, operations, flags, tiers) |
+| **AlloyDB** | (no benchmark infra yet) | 14 commands total |
+| **Looker** | (no benchmark infra yet) | 6 commands total |
+
+Benchmark task files:
+- `benchmarks/tasks/bigquery_overlap.yaml` — updated with jobs/models/routines + mutation dry-runs
+- `benchmarks/tasks/spanner_overlap.yaml` — updated with backups/instance-configs/database-operations
+- `benchmarks/tasks/cloudsql_overlap.yaml` — new file for Cloud SQL parity tasks
+
 ## Architectural Factors (Inference)
 
 The sections above report measured results. This section offers an
@@ -239,12 +258,14 @@ unintended successful response instead of an error signal.
 
 ## Next Steps
 
+- Rerun benchmarks with expanded task suite (BigQuery jobs/models/routines, Spanner backups/configs, Cloud SQL)
 - Update query/dry-run validation specs to match Go output shape
 - Rerun on a Linux CI host (GitHub Actions runner) to confirm the speedup
   is not macOS-specific
 - Increase warm trials to 10+ for statistical claims
 - Add field filtering to reduce Go token cost to Rust-level or below
 - Rerun with a genuinely restricted project for the permission-denied task
+- Add mutation latency benchmarks (dry-run + live create/delete round-trips)
 
 ## Artifacts
 

--- a/docs/benchmark_results_bigquery.md
+++ b/docs/benchmark_results_bigquery.md
@@ -206,7 +206,7 @@ not yet been measured:
 
 | Surface | New tasks | Commands |
 |---|---|---|
-| **BigQuery** | jobs list, models list, routines list, mutation dry-runs | 9 new commands (jobs list/get, models list/get, routines list/get, datasets insert/delete, tables insert/delete) |
+| **BigQuery** | jobs list, models list, routines list, mutation dry-runs | 10 new commands (jobs list/get, models list/get, routines list/get, datasets insert/delete, tables insert/delete) |
 | **Spanner** | backups list, instance-configs list, database-operations list, update-ddl dry-run | 10 new commands (databases create/drop/update-ddl, backups list/get/create/delete, databaseOperations list, instanceConfigs list/get) |
 | **Cloud SQL** | instances list, flags list, tiers list, operations list | 17 commands total (CRUD for databases + users, backupRuns, operations, flags, tiers) |
 | **AlloyDB** | (no benchmark infra yet) | 14 commands total |

--- a/docs/cli_benchmark_plan.md
+++ b/docs/cli_benchmark_plan.md
@@ -28,8 +28,9 @@ Use two scoreboards:
 
 - **Parity benchmark**
   Compare only overlapping surfaces:
-  - BigQuery dataset/table/query tasks
-  - Spanner instance/database/DDL/query tasks
+  - BigQuery dataset/table/query/jobs/models/routines tasks
+  - Spanner instance/database/DDL/backup/instance-config tasks
+  - Cloud SQL instance/database/flags/tiers/operations tasks
 - **Differentiated benchmark**
   Measure `dcx` features that `bq` and Spanner CLI do not really have:
   - `meta commands`


### PR DESCRIPTION
## Summary

Updates benchmark task definitions and documentation to reflect the expanded 81-command surface (up from 12 tasks originally).

### Benchmark tasks added

| File | New tasks | What |
|---|---|---|
| `bigquery_overlap.yaml` | 5 tasks | jobs list, models list, routines list, datasets insert dry-run, datasets delete dry-run |
| `spanner_overlap.yaml` | 4 tasks | backups list, instance-configs list, database-operations list, update-ddl dry-run |
| `cloudsql_overlap.yaml` | 4 tasks (new file) | instances list, flags list, tiers list, operations list |
| `dcx_differentiated.yaml` | 1 fix | meta describe target changed from unshipped `analytics evaluate` to `spanner databases update-ddl` |

### Docs updated

- `benchmark_results_bigquery.md` — "Expanded Surface" section documenting 38→81 command growth with task coverage status
- `cli_benchmark_plan.md` — parity surface list expanded to include Cloud SQL, BigQuery jobs/models/routines, Spanner backups/configs
- `manifest.yaml` — CloudSQL and AlloyDB placeholder bindings added

### Not yet done

- Running the actual expanded benchmarks (requires live infrastructure provisioning)
- AlloyDB/Looker benchmark tasks (no parity CLI to compare against)

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes
- [x] YAML task files are syntactically valid
- [x] No code changes — docs and benchmark definitions only

🤖 Generated with [Claude Code](https://claude.com/claude-code)