### PR TITLE
Add meta generate-skills to auto-generate SKILL.md from contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An agent-native CLI for Google Cloud's Data Cloud, built in Go.
 One binary for BigQuery, Spanner, AlloyDB, Cloud SQL, and Looker —
 with structured output, typed errors, and an MCP bridge for AI agents.
 
-> **Status:** Go MVP functional — 81 commands across 11 domains.
+> **Status:** Go MVP functional — 82 commands across 11 domains.
 > Benchmarked at **5x faster** than `bq` with token cost within 6%.
 > See [docs/benchmark_results_bigquery.md](docs/benchmark_results_bigquery.md)
 > for measured results.
@@ -54,7 +54,7 @@ source <(dcx completion bash)
 dcx mcp serve
 ```
 
-## Commands (81 total)
+## Commands (82 total)
 
 | Surface | Commands |
 |---|---|
@@ -66,7 +66,7 @@ dcx mcp serve
 | **CA** | `ca ask`, `ca create-agent`, `ca list-agents`, `ca add-verified-query` |
 | **Auth** | `auth status`, `auth check` |
 | **Profiles** | `profiles list`, `profiles validate`, `profiles test` |
-| **Introspection** | `meta commands`, `meta describe` |
+| **Introspection** | `meta commands`, `meta describe`, `meta generate-skills` |
 | **MCP** | `mcp serve` (JSON-RPC 2.0 / stdio, read-only, default `json-minified`) |
 | **Skills** | `dcx-bigquery`, `dcx-databases`, `dcx-looker`, `dcx-ca` (checked-in) |
 
@@ -75,7 +75,7 @@ Run `dcx meta commands` for the full machine-readable list.
 ### Deferred to P1
 
 - Agent Analytics SDK (12 commands, 6 evaluators)
-- `generate-skills`, Gemini manifest
+- Gemini manifest
 - Model Armor sanitization
 
 ## Output Format

--- a/docs/go_mvp_plan.md
+++ b/docs/go_mvp_plan.md
@@ -208,7 +208,7 @@ CLI can continue serving this surface during the Go migration.
 
 ### P1: Management and generation helpers
 
-- `generate-skills`
+- ~~`generate-skills`~~ — **shipped** (PR #24, as `meta generate-skills`)
 - Gemini manifest generation (`meta gemini-tools`)
 - ~~shell completions~~ — **shipped** (PR #15)
 - ~~`ca create-agent`, `ca list-agents`, `ca add-verified-query`~~ — **shipped** (PR #7)
@@ -717,7 +717,7 @@ The right message is:
 
 ## Implementation status
 
-All 6 phases are complete. The Go MVP is functional with 81 commands
+All 6 phases are complete. The Go MVP is functional with 82 commands
 across 11 domains, benchmarked at 5x faster than `bq`.
 
 | Phase | Status | PR |

--- a/internal/cli/generate_skills.go
+++ b/internal/cli/generate_skills.go
@@ -52,6 +52,11 @@ By default writes to stdout. Use --out-dir to write files to a directory.`,
 				for _, d := range domains {
 					if cmds, ok := byDomain[d]; ok {
 						filtered[d] = cmds
+					} else {
+						dcxerrors.Emit(dcxerrors.InvalidConfig,
+							fmt.Sprintf("unknown domain %q", d),
+							fmt.Sprintf("Valid domains: %s", strings.Join(sortedDomainKeys(byDomain), ", ")))
+						return nil
 					}
 				}
 				byDomain = filtered

--- a/internal/cli/generate_skills.go
+++ b/internal/cli/generate_skills.go
@@ -1,0 +1,268 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/haiyuan-eng-google/dcx-cli/internal/contracts"
+	dcxerrors "github.com/haiyuan-eng-google/dcx-cli/internal/errors"
+	"github.com/spf13/cobra"
+)
+
+func (a *App) addGenerateSkillsCommand() {
+	var outDir string
+	var domains []string
+
+	// Find or create the "meta" group command.
+	var metaCmd *cobra.Command
+	for _, child := range a.Root.Commands() {
+		if child.Name() == "meta" {
+			metaCmd = child
+			break
+		}
+	}
+	if metaCmd == nil {
+		return
+	}
+
+	cmd := &cobra.Command{
+		Use:   "generate-skills",
+		Short: "Generate SKILL.md files from the command contract registry",
+		Long: `Generate SKILL.md files for each domain from the machine-readable
+contract registry. Each skill file includes command routing tables,
+flag details, and decision rules derived from the live contracts.
+
+By default writes to stdout. Use --out-dir to write files to a directory.`,
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			all := a.Registry.All()
+			if len(all) == 0 {
+				dcxerrors.Emit(dcxerrors.Internal, "no contracts registered", "")
+				return nil
+			}
+
+			// Group by domain.
+			byDomain := groupByDomain(all)
+
+			// Filter domains if specified.
+			if len(domains) > 0 {
+				filtered := make(map[string][]*contracts.CommandContract)
+				for _, d := range domains {
+					if cmds, ok := byDomain[d]; ok {
+						filtered[d] = cmds
+					}
+				}
+				byDomain = filtered
+			}
+
+			if outDir != "" {
+				return writeSkillFiles(byDomain, outDir)
+			}
+
+			// Write to stdout.
+			for _, domain := range sortedDomainKeys(byDomain) {
+				content := renderSkill(domain, byDomain[domain])
+				fmt.Println(content)
+				fmt.Println("---")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&outDir, "out-dir", "", "Directory to write SKILL.md files (default: stdout)")
+	cmd.Flags().StringSliceVar(&domains, "domains", nil, "Comma-separated domains to generate (default: all)")
+
+	metaCmd.AddCommand(cmd)
+
+	a.Registry.Register(contracts.BuildContract(
+		"meta generate-skills", "meta",
+		"Generate SKILL.md files from the command contract registry",
+		[]contracts.FlagContract{
+			{Name: "out-dir", Type: "string", Description: "Directory to write SKILL.md files"},
+			{Name: "domains", Type: "string", Description: "Comma-separated domains to generate"},
+		},
+		false, false,
+	))
+}
+
+func groupByDomain(all []*contracts.CommandContract) map[string][]*contracts.CommandContract {
+	result := make(map[string][]*contracts.CommandContract)
+	for _, c := range all {
+		// Skip meta/internal domains from skill generation.
+		if c.Domain == "meta" || c.Domain == "mcp" || c.Domain == "cli" {
+			continue
+		}
+		result[c.Domain] = append(result[c.Domain], c)
+	}
+	return result
+}
+
+func sortedDomainKeys(m map[string][]*contracts.CommandContract) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func writeSkillFiles(byDomain map[string][]*contracts.CommandContract, outDir string) error {
+	for _, domain := range sortedDomainKeys(byDomain) {
+		content := renderSkill(domain, byDomain[domain])
+		dir := filepath.Join(outDir, "dcx-"+domain)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("creating directory %s: %w", dir, err)
+		}
+		path := filepath.Join(dir, "SKILL.md")
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			return fmt.Errorf("writing %s: %w", path, err)
+		}
+		fmt.Fprintf(os.Stderr, "wrote %s (%d commands)\n", path, len(byDomain[domain]))
+	}
+	return nil
+}
+
+func renderSkill(domain string, cmds []*contracts.CommandContract) string {
+	var b strings.Builder
+
+	domainTitle := domainDisplayName(domain)
+
+	// Frontmatter.
+	b.WriteString("---\n")
+	b.WriteString(fmt.Sprintf("name: dcx-%s\n", domain))
+	b.WriteString(fmt.Sprintf("description: %s commands for dcx — auto-generated from the contract registry.\n", domainTitle))
+	b.WriteString("---\n\n")
+
+	// Separate reads and mutations.
+	var reads, mutations []*contracts.CommandContract
+	for _, c := range cmds {
+		if c.IsMutation {
+			mutations = append(mutations, c)
+		} else {
+			reads = append(reads, c)
+		}
+	}
+
+	// When to use.
+	b.WriteString("## When to use this skill\n\n")
+	b.WriteString(fmt.Sprintf("Use when the user wants to work with %s resources via dcx.\n\n", domainTitle))
+
+	// Command routing table.
+	b.WriteString("## Commands\n\n")
+	if len(reads) > 0 {
+		b.WriteString("### Read commands\n\n")
+		b.WriteString("| Command | Description |\n")
+		b.WriteString("|---------|-------------|\n")
+		for _, c := range reads {
+			desc := truncateDesc(c.Description, 80)
+			b.WriteString(fmt.Sprintf("| `%s` | %s |\n", c.Command, desc))
+		}
+		b.WriteString("\n")
+	}
+
+	if len(mutations) > 0 {
+		b.WriteString("### Mutation commands\n\n")
+		b.WriteString("| Command | Description | Flags |\n")
+		b.WriteString("|---------|-------------|-------|\n")
+		for _, c := range mutations {
+			desc := truncateDesc(c.Description, 60)
+			mutFlags := mutationFlagSummary(c)
+			b.WriteString(fmt.Sprintf("| `%s` | %s | %s |\n", c.Command, desc, mutFlags))
+		}
+		b.WriteString("\n")
+		b.WriteString("All mutation commands support `--dry-run` to preview the request without executing.\n\n")
+	}
+
+	// Flag reference for commands with non-global flags.
+	b.WriteString("## Flag reference\n\n")
+	for _, c := range cmds {
+		cmdFlags := nonGlobalFlags(c)
+		if len(cmdFlags) == 0 {
+			continue
+		}
+		b.WriteString(fmt.Sprintf("### `%s`\n\n", c.Command))
+		b.WriteString("| Flag | Type | Required | Description |\n")
+		b.WriteString("|------|------|----------|-------------|\n")
+		for _, f := range cmdFlags {
+			req := ""
+			if f.Required {
+				req = "Yes"
+			}
+			b.WriteString(fmt.Sprintf("| `--%s` | %s | %s | %s |\n", f.Name, f.Type, req, truncateDesc(f.Description, 60)))
+		}
+		b.WriteString("\n")
+	}
+
+	// Decision rules.
+	b.WriteString("## Decision rules\n\n")
+	b.WriteString(fmt.Sprintf("- All %s commands require `--project-id` (or `DCX_PROJECT`)\n", domainTitle))
+	b.WriteString("- Use `--format json` for automation, `--format table` for visual scanning\n")
+	if len(mutations) > 0 {
+		b.WriteString("- Mutation commands require `--body` (POST) or `--force` (DELETE)\n")
+		b.WriteString("- Use `--dry-run` to preview mutations before executing\n")
+		b.WriteString("- DELETE commands require `--force` in non-interactive environments\n")
+	}
+	b.WriteString("- Use `dcx meta describe <command>` for the full contract of any command\n")
+
+	return b.String()
+}
+
+func domainDisplayName(domain string) string {
+	switch domain {
+	case "bigquery":
+		return "BigQuery"
+	case "spanner":
+		return "Spanner"
+	case "alloydb":
+		return "AlloyDB"
+	case "cloudsql":
+		return "Cloud SQL"
+	case "looker":
+		return "Looker"
+	case "ca":
+		return "Conversational Analytics"
+	case "auth":
+		return "Authentication"
+	case "profiles":
+		return "Profiles"
+	default:
+		return strings.Title(domain)
+	}
+}
+
+func truncateDesc(s string, maxLen int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) > maxLen {
+		return s[:maxLen-3] + "..."
+	}
+	return s
+}
+
+func mutationFlagSummary(c *contracts.CommandContract) string {
+	var parts []string
+	for _, f := range c.Flags {
+		if f.Name == "body" {
+			parts = append(parts, "`--body`")
+		} else if f.Name == "force" {
+			parts = append(parts, "`--force`")
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+func nonGlobalFlags(c *contracts.CommandContract) []contracts.FlagContract {
+	globalFlags := map[string]bool{
+		"format": true, "project-id": true, "dataset-id": true,
+		"location": true, "token": true, "credentials-file": true,
+		"dry-run": true,
+	}
+	var result []contracts.FlagContract
+	for _, f := range c.Flags {
+		if !globalFlags[f.Name] {
+			result = append(result, f)
+		}
+	}
+	return result
+}

--- a/internal/cli/generate_skills.go
+++ b/internal/cli/generate_skills.go
@@ -172,7 +172,17 @@ func renderSkill(domain string, cmds []*contracts.CommandContract) string {
 			b.WriteString(fmt.Sprintf("| `%s` | %s | %s |\n", c.Command, desc, mutFlags))
 		}
 		b.WriteString("\n")
-		b.WriteString("All mutation commands support `--dry-run` to preview the request without executing.\n\n")
+		// Only mention dry-run if at least one mutation supports it.
+		hasDryRun := false
+		for _, c := range mutations {
+			if c.SupportsDryRun {
+				hasDryRun = true
+				break
+			}
+		}
+		if hasDryRun {
+			b.WriteString("Mutations marked with `--dry-run` support previewing the request without executing.\n\n")
+		}
 	}
 
 	// Flag reference for commands with non-global flags.
@@ -195,14 +205,38 @@ func renderSkill(domain string, cmds []*contracts.CommandContract) string {
 		b.WriteString("\n")
 	}
 
-	// Decision rules.
+	// Decision rules — derived from actual contracts, not hardcoded.
 	b.WriteString("## Decision rules\n\n")
-	b.WriteString(fmt.Sprintf("- All %s commands require `--project-id` (or `DCX_PROJECT`)\n", domainTitle))
+	if domainRequiresProjectID(domain, cmds) {
+		b.WriteString(fmt.Sprintf("- All %s commands require `--project-id` (or `DCX_PROJECT`)\n", domainTitle))
+	}
 	b.WriteString("- Use `--format json` for automation, `--format table` for visual scanning\n")
 	if len(mutations) > 0 {
-		b.WriteString("- Mutation commands require `--body` (POST) or `--force` (DELETE)\n")
-		b.WriteString("- Use `--dry-run` to preview mutations before executing\n")
-		b.WriteString("- DELETE commands require `--force` in non-interactive environments\n")
+		hasDryRun := false
+		hasBody := false
+		hasForce := false
+		for _, c := range mutations {
+			if c.SupportsDryRun {
+				hasDryRun = true
+			}
+			for _, f := range c.Flags {
+				if f.Name == "body" {
+					hasBody = true
+				}
+				if f.Name == "force" {
+					hasForce = true
+				}
+			}
+		}
+		if hasBody {
+			b.WriteString("- POST/PATCH mutations require `--body` (JSON string or `@file.json`)\n")
+		}
+		if hasForce {
+			b.WriteString("- DELETE commands require `--force` in non-interactive environments\n")
+		}
+		if hasDryRun {
+			b.WriteString("- Use `--dry-run` to preview mutations before executing\n")
+		}
 	}
 	b.WriteString("- Use `dcx meta describe <command>` for the full contract of any command\n")
 
@@ -250,6 +284,31 @@ func mutationFlagSummary(c *contracts.CommandContract) string {
 		}
 	}
 	return strings.Join(parts, ", ")
+}
+
+// domainRequiresProjectID checks if all commands in a domain actually use
+// --project-id. Returns false for domains like auth and profiles where
+// commands work without it.
+func domainRequiresProjectID(domain string, cmds []*contracts.CommandContract) bool {
+	switch domain {
+	case "auth", "profiles":
+		return false
+	}
+	// Check if any command has project-id as a required flag.
+	for _, c := range cmds {
+		for _, f := range c.Flags {
+			if f.Name == "project-id" && f.Required {
+				return true
+			}
+		}
+	}
+	// Default true for data domains even if flag isn't marked required
+	// (global flags are typically not marked required in contracts).
+	switch domain {
+	case "bigquery", "spanner", "alloydb", "cloudsql", "looker":
+		return true
+	}
+	return false
 }
 
 func nonGlobalFlags(c *contracts.CommandContract) []contracts.FlagContract {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -72,6 +72,9 @@ Structured output, typed errors, and an MCP bridge for AI agents.`,
 	registry.Register(contracts.MetaCommandsContract())
 	registry.Register(contracts.MetaDescribeContract())
 
+	// Register generate-skills command (must be after meta commands).
+	app.addGenerateSkillsCommand()
+
 	// Register Discovery-driven commands.
 	app.registerBigQueryDiscoveryCommands()
 	app.registerDataCloudDiscoveryCommands()

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -137,7 +137,7 @@ func TestCommandDiscovery(t *testing.T) {
 		// Profiles
 		"dcx profiles list", "dcx profiles validate", "dcx profiles test",
 		// Meta
-		"dcx meta commands", "dcx meta describe",
+		"dcx meta commands", "dcx meta describe", "dcx meta generate-skills",
 		// MCP
 		"dcx mcp serve",
 		// Completion
@@ -155,8 +155,8 @@ func TestCommandDiscovery(t *testing.T) {
 		}
 	}
 
-	if len(commands) < 81 {
-		t.Errorf("expected at least 81 commands, got %d", len(commands))
+	if len(commands) < 82 {
+		t.Errorf("expected at least 82 commands, got %d", len(commands))
 	}
 }
 


### PR DESCRIPTION
## Summary

New command: `dcx meta generate-skills` (81 → 82 commands). Reads the live contract registry and generates SKILL.md files for each domain.

### Usage

```bash
# All domains to stdout
dcx meta generate-skills

# Write files to a directory
dcx meta generate-skills --out-dir skills/generated/

# Specific domains only
dcx meta generate-skills --domains bigquery,spanner --out-dir skills/generated/
```

### Generated output

Each SKILL.md includes:
- Frontmatter (`name`, `description`)
- Read command routing table
- Mutation command routing table (with `--body`/`--force` flag summary)
- Non-global flag reference per command
- Decision rules (mutation safety, dry-run, format guidance)

Generates 8 skill files covering all data domains:

| Domain | Commands | Mutations |
|---|---|---|
| bigquery | 15 | datasets insert/delete, tables insert/delete |
| spanner | 16 | databases create/drop/update-ddl, backups create/delete |
| alloydb | 14 | users create/delete |
| cloudsql | 17 | databases insert/delete, users insert/delete |
| looker | 6 | — |
| ca | 4 | create-agent, add-verified-query |
| auth | 2 | — |
| profiles | 3 | — |

Excludes `meta`, `mcp`, and `cli` domains (internal tooling).

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes
- [x] stdout mode renders all 8 domains
- [x] `--out-dir` writes 8 `dcx-{domain}/SKILL.md` files
- [x] `--domains` filters correctly
- [x] Contract registered, appears in `meta commands` (82 total)
- [x] Docs updated (82 commands, removed from P1 deferred list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)