### PR TITLE
Add spanner operations get/wait for async operation polling (issue #26 item 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An agent-native CLI for Google Cloud's Data Cloud, built in Go.
 One binary for BigQuery, Spanner, AlloyDB, Cloud SQL, and Looker —
 with structured output, typed errors, and an MCP bridge for AI agents.
 
-> **Status:** Go MVP functional — 82 commands across 11 domains.
+> **Status:** Go MVP functional — 84 commands across 11 domains.
 > Benchmarked at **5x faster** than `bq` with token cost within 6%.
 > See [docs/benchmark_results.md](docs/benchmark_results.md)
 > for measured results.
@@ -54,12 +54,12 @@ source <(dcx completion bash)
 dcx mcp serve
 ```
 
-## Commands (82 total)
+## Commands (84 total)
 
 | Surface | Commands |
 |---|---|
 | **BigQuery** | `datasets list/get/insert/delete`, `tables list/get/insert/delete`, `jobs list/get/query`, `models list/get`, `routines list/get` |
-| **Spanner** | `instances list/get`, `databases list/get/get-ddl/create/drop-database/update-ddl`, `backups list/get/create/delete`, `databaseOperations list`, `instanceConfigs list/get`, `schema describe` |
+| **Spanner** | `instances list/get`, `databases list/get/get-ddl/create/drop-database/update-ddl`, `backups list/get/create/delete`, `operations get/wait`, `databaseOperations list`, `instanceConfigs list/get`, `schema describe` |
 | **AlloyDB** | `clusters list/get`, `instances list/get`, `backups list/get`, `users list/get/create/delete`, `operations list/get`, `databases list`, `schema describe` |
 | **Cloud SQL** | `instances list/get`, `databases list/get/insert/delete`, `backupRuns list/get`, `users list/get/insert/delete`, `operations list/get`, `flags list`, `tiers list`, `schema describe` |
 | **Looker** | `instances list/get`, `backups list/get`, `explores list`, `dashboards get` |

--- a/docs/go_mvp_plan.md
+++ b/docs/go_mvp_plan.md
@@ -717,7 +717,7 @@ The right message is:
 
 ## Implementation status
 
-All 6 phases are complete. The Go MVP is functional with 82 commands
+All 6 phases are complete. The Go MVP is functional with 84 commands
 across 11 domains, benchmarked at 5x faster than `bq`.
 
 | Phase | Status | PR |

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -90,8 +90,9 @@ Structured output, typed errors, and an MCP bridge for AI agents.`,
 	// Register CA commands.
 	app.addCACommands()
 
-	// Register static Spanner commands (update-ddl with ergonomic flags).
+	// Register static Spanner commands.
 	app.registerSpannerUpdateDdlCommand()
+	app.registerSpannerOperationsCommands()
 
 	// Register Data Cloud helper commands (schema describe, databases list via QueryData).
 	app.registerDataCloudHelperCommands()

--- a/internal/cli/spanner_operations.go
+++ b/internal/cli/spanner_operations.go
@@ -138,14 +138,20 @@ On timeout: emits a structured error to stderr (exit 2, retryable).`,
 					return a.Render(format, result)
 				}
 
-				if time.Now().Add(interval).After(deadline) {
+				if time.Now().After(deadline) {
 					dcxerrors.Emit(dcxerrors.InfraError,
 						fmt.Sprintf("operation timed out after %ds", timeoutSecs),
 						fmt.Sprintf("Operation still running: %s", operationName))
 					return nil
 				}
 
-				time.Sleep(interval)
+				// Sleep the lesser of poll interval or remaining time.
+				remaining := time.Until(deadline)
+				if remaining > interval {
+					time.Sleep(interval)
+				} else if remaining > 0 {
+					time.Sleep(remaining)
+				}
 			}
 		},
 	}

--- a/internal/cli/spanner_operations.go
+++ b/internal/cli/spanner_operations.go
@@ -1,0 +1,220 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/haiyuan-eng-google/dcx-cli/internal/auth"
+	"github.com/haiyuan-eng-google/dcx-cli/internal/contracts"
+	dcxerrors "github.com/haiyuan-eng-google/dcx-cli/internal/errors"
+	"github.com/spf13/cobra"
+)
+
+const spannerOperationsURL = "https://spanner.googleapis.com/v1/%s"
+
+func (a *App) registerSpannerOperationsCommands() {
+	// Find the spanner group command.
+	var spannerCmd *cobra.Command
+	for _, child := range a.Root.Commands() {
+		if child.Name() == "spanner" {
+			spannerCmd = child
+			break
+		}
+	}
+	if spannerCmd == nil {
+		return
+	}
+
+	// Find or create operations group.
+	var opsCmd *cobra.Command
+	for _, child := range spannerCmd.Commands() {
+		if child.Name() == "operations" {
+			opsCmd = child
+			break
+		}
+	}
+	if opsCmd == nil {
+		opsCmd = &cobra.Command{
+			Use:   "operations",
+			Short: "Spanner long-running operation commands",
+		}
+		spannerCmd.AddCommand(opsCmd)
+	}
+
+	a.registerSpannerOpsGet(opsCmd)
+	a.registerSpannerOpsWait(opsCmd)
+}
+
+func (a *App) registerSpannerOpsGet(parent *cobra.Command) {
+	var operationName string
+
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Get the status of a Spanner long-running operation",
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			if operationName == "" {
+				dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --operation-name is missing", "")
+				return nil
+			}
+
+			format, err := a.OutputFormat()
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.InvalidConfig, err.Error(), "")
+				return nil
+			}
+
+			result, err := fetchSpannerOperation(a.AuthConfig(), operationName)
+			if err != nil {
+				dcxerrors.EmitAPIError(err)
+				return nil
+			}
+
+			return a.Render(format, result)
+		},
+	}
+
+	cmd.Flags().StringVar(&operationName, "operation-name", "", "Full operation resource name (required)")
+	parent.AddCommand(cmd)
+
+	a.Registry.Register(contracts.BuildContract(
+		"spanner operations get", "spanner",
+		"Get the status of a Spanner long-running operation",
+		[]contracts.FlagContract{
+			{Name: "operation-name", Type: "string", Description: "Full operation resource name", Required: true},
+		},
+		false, false,
+	))
+}
+
+func (a *App) registerSpannerOpsWait(parent *cobra.Command) {
+	var operationName string
+	var timeoutSecs int
+	var pollIntervalSecs int
+
+	cmd := &cobra.Command{
+		Use:   "wait",
+		Short: "Wait for a Spanner long-running operation to complete",
+		Long: `Poll a Spanner long-running operation until it completes or times out.
+Quiet during polling — outputs nothing until completion or timeout.
+
+On success: outputs the operation result to stdout.
+On timeout: emits a structured error to stderr (exit 2, retryable).`,
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			if operationName == "" {
+				dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --operation-name is missing", "")
+				return nil
+			}
+			if timeoutSecs <= 0 {
+				dcxerrors.Emit(dcxerrors.InvalidConfig, "--timeout must be positive", "")
+				return nil
+			}
+			if pollIntervalSecs <= 0 {
+				dcxerrors.Emit(dcxerrors.InvalidConfig, "--poll-interval must be positive", "")
+				return nil
+			}
+
+			format, err := a.OutputFormat()
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.InvalidConfig, err.Error(), "")
+				return nil
+			}
+
+			deadline := time.Now().Add(time.Duration(timeoutSecs) * time.Second)
+			interval := time.Duration(pollIntervalSecs) * time.Second
+
+			for {
+				result, err := fetchSpannerOperation(a.AuthConfig(), operationName)
+				if err != nil {
+					dcxerrors.EmitAPIError(err)
+					return nil
+				}
+
+				done, _ := result["done"].(bool)
+				if done {
+					return a.Render(format, result)
+				}
+
+				if time.Now().Add(interval).After(deadline) {
+					dcxerrors.Emit(dcxerrors.InfraError,
+						fmt.Sprintf("operation timed out after %ds", timeoutSecs),
+						fmt.Sprintf("Operation still running: %s", operationName))
+					return nil
+				}
+
+				time.Sleep(interval)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&operationName, "operation-name", "", "Full operation resource name (required)")
+	cmd.Flags().IntVar(&timeoutSecs, "timeout", 300, "Timeout in seconds (default 300)")
+	cmd.Flags().IntVar(&pollIntervalSecs, "poll-interval", 2, "Poll interval in seconds (default 2)")
+	parent.AddCommand(cmd)
+
+	a.Registry.Register(contracts.BuildContract(
+		"spanner operations wait", "spanner",
+		"Wait for a Spanner long-running operation to complete",
+		[]contracts.FlagContract{
+			{Name: "operation-name", Type: "string", Description: "Full operation resource name", Required: true},
+			{Name: "timeout", Type: "int", Description: "Timeout in seconds (default 300)"},
+			{Name: "poll-interval", Type: "int", Description: "Poll interval in seconds (default 2)"},
+		},
+		false, false,
+	))
+}
+
+// fetchSpannerOperation calls GET v1/{name} on the Spanner Operations API.
+func fetchSpannerOperation(authCfg auth.Config, operationName string) (map[string]interface{}, error) {
+	ctx := context.Background()
+	resolved, err := auth.Resolve(ctx, authCfg)
+	if err != nil {
+		return nil, fmt.Errorf("auth: %w", err)
+	}
+	tok, err := resolved.TokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("token: %w", err)
+	}
+
+	apiURL := fmt.Sprintf(spannerOperationsURL, operationName)
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode >= 400 {
+		var apiErr struct {
+			Error struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		message := fmt.Sprintf("API returned HTTP %d", resp.StatusCode)
+		if json.Unmarshal(body, &apiErr) == nil && apiErr.Error.Message != "" {
+			message = apiErr.Error.Message
+		}
+		return nil, &dcxerrors.APIHTTPError{
+			StatusCode: resp.StatusCode,
+			Message:    message,
+			RetryAfter: resp.Header.Get("Retry-After"),
+		}
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parsing response: %w", err)
+	}
+	return result, nil
+}

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -106,6 +106,7 @@ func TestCommandDiscovery(t *testing.T) {
 		"dcx spanner backups list", "dcx spanner backups get",
 		"dcx spanner backups create", "dcx spanner backups delete",
 		"dcx spanner database-operations list",
+		"dcx spanner operations get", "dcx spanner operations wait",
 		"dcx spanner instance-configs list", "dcx spanner instance-configs get",
 		// AlloyDB
 		"dcx alloydb clusters list", "dcx alloydb clusters get",
@@ -155,8 +156,8 @@ func TestCommandDiscovery(t *testing.T) {
 		}
 	}
 
-	if len(commands) < 82 {
-		t.Errorf("expected at least 82 commands, got %d", len(commands))
+	if len(commands) < 84 {
+		t.Errorf("expected at least 84 commands, got %d", len(commands))
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -153,8 +153,12 @@ func (s *Server) handleToolsList(req JSONRPCRequest) {
 		if c.Domain == "meta" || c.Domain == "auth" || c.Domain == "profiles" || c.Domain == "mcp" {
 			continue
 		}
-		// Only expose read-only commands.
+		// Only expose read-only, non-blocking commands.
 		if c.IsMutation {
+			continue
+		}
+		// Exclude long-polling commands (not suitable for tool calls).
+		if strings.HasSuffix(c.Command, " wait") {
 			continue
 		}
 
@@ -176,9 +180,14 @@ func (s *Server) handleToolsCall(req JSONRPCRequest) {
 		return
 	}
 
-	// Block mutations — MCP bridge is read-only.
-	if contract, ok := s.Registry.Get(toolNameToCommand(params.Name)); ok && contract.IsMutation {
+	// Block mutations and long-polling commands.
+	cmdName := toolNameToCommand(params.Name)
+	if contract, ok := s.Registry.Get(cmdName); ok && contract.IsMutation {
 		s.writeError(req.ID, -32601, "Method not allowed", "MCP bridge is read-only; mutation commands are not available")
+		return
+	}
+	if strings.HasSuffix(cmdName, " wait") {
+		s.writeError(req.ID, -32601, "Method not allowed", "Long-polling commands are not available via MCP")
 		return
 	}
 


### PR DESCRIPTION
## Summary

Two new commands for polling Spanner long-running operations (82 → 84 total). Implements issue #26 item 2 (Spanner scope).

### Commands

```bash
# Check status
dcx spanner operations get --operation-name=projects/X/instances/Y/databases/Z/operations/ABC

# Wait for completion (quiet until done or timeout)
dcx spanner operations wait --operation-name=projects/X/instances/Y/databases/Z/operations/ABC --timeout=60
```

### Wait behavior

- Polls every `--poll-interval` seconds (default 2)
- **Quiet during polling** — no stdout until completion
- On success: outputs completed operation to stdout, exit 0
- On timeout: `INFRA_ERROR` with `retryable: true` to stderr, exit 2

```json
{"error":{"code":"INFRA_ERROR","message":"operation timed out after 60s","hint":"Operation still running: projects/X/operations/Y","exit_code":2,"retryable":true,"status":"error"}}
```

### Agent workflow

```bash
# Create → wait → verify (reliable, no arbitrary sleeps)
OP=$(dcx spanner databases update-ddl --ddl "CREATE TABLE t (id INT64) PRIMARY KEY (id)" --format json-minified | jq -r .name)
dcx spanner operations wait --operation-name="$OP" --timeout=120
dcx spanner databases get-ddl --instance-id=myinst --database-id=mydb
```

### Design decisions

- Static commands (not Discovery) — Spanner has 6 `operations` resources at different nesting levels that would collide in the Discovery pipeline
- Uses `GET v1/{name}` which works for all operation types (database, backup, instance, DDL)
- Input validation: `--timeout=0` and `--poll-interval=0` rejected before polling
- 429s handled via `APIHTTPError` (PR #27)

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes
- [x] E2E: `update-ddl` → `operations get` (done=false) → `operations wait` (done=true) → `get-ddl` confirms schema
- [x] Docs updated (84 commands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)