### PR TITLE
Add --retry flag with shared exponential backoff helper (issue #30 item 1)

### DIFF
--- a/internal/bigquery/query.go
+++ b/internal/bigquery/query.go
@@ -13,6 +13,7 @@ import (
 	"github.com/haiyuan-eng-google/dcx-cli/internal/auth"
 	dcxerrors "github.com/haiyuan-eng-google/dcx-cli/internal/errors"
 	"github.com/haiyuan-eng-google/dcx-cli/internal/output"
+	"github.com/haiyuan-eng-google/dcx-cli/internal/retry"
 )
 
 const bigqueryJobsURL = "https://bigquery.googleapis.com/bigquery/v2/projects/%s/queries"
@@ -84,6 +85,7 @@ func ExecuteQuery(
 	maxResults int,
 	format output.Format,
 	outputFields string,
+	maxRetries int,
 ) error {
 	if projectID == "" {
 		dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --project-id is missing", "")
@@ -122,19 +124,19 @@ func ExecuteQuery(
 		return nil
 	}
 
-	url := fmt.Sprintf(bigqueryJobsURL, projectID)
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(bodyJSON))
-	if err != nil {
-		dcxerrors.Emit(dcxerrors.Internal, fmt.Sprintf("creating request: %v", err), "")
-		return nil
-	}
+	apiURL := fmt.Sprintf(bigqueryJobsURL, projectID)
 
-	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-
-	// Execute request.
-	resp, err := http.DefaultClient.Do(req)
+	// Execute request with retry.
+	resp, err := retry.Do(nil, func() (*http.Request, error) {
+		r, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewReader(bodyJSON))
+		if err != nil {
+			return nil, err
+		}
+		r.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+		r.Header.Set("Content-Type", "application/json")
+		r.Header.Set("Accept", "application/json")
+		return r, nil
+	}, maxRetries)
 	if err != nil {
 		dcxerrors.Emit(dcxerrors.InfraError, fmt.Sprintf("API request failed: %v", err), "Check network connectivity")
 		return nil

--- a/internal/ca/client.go
+++ b/internal/ca/client.go
@@ -13,6 +13,7 @@ import (
 
 	dcxerrors "github.com/haiyuan-eng-google/dcx-cli/internal/errors"
 	"github.com/haiyuan-eng-google/dcx-cli/internal/profiles"
+	"github.com/haiyuan-eng-google/dcx-cli/internal/retry"
 )
 
 const (
@@ -35,14 +36,47 @@ const (
 // Client provides access to the Conversational Analytics APIs.
 type Client struct {
 	HTTPClient *http.Client
+	MaxRetries int
 }
 
 // NewClient creates a CA client.
-func NewClient(httpClient *http.Client) *Client {
+func NewClient(httpClient *http.Client, maxRetries int) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	return &Client{HTTPClient: httpClient}
+	return &Client{HTTPClient: httpClient, MaxRetries: maxRetries}
+}
+
+// do executes an HTTP request with retry support.
+func (c *Client) do(req *http.Request) (*http.Response, error) {
+	if c.MaxRetries <= 0 {
+		return c.HTTPClient.Do(req)
+	}
+	// Clone request essentials for retry builder.
+	method := req.Method
+	url := req.URL.String()
+	headers := req.Header.Clone()
+	var bodyBytes []byte
+	if req.Body != nil {
+		bodyBytes, _ = io.ReadAll(req.Body)
+		req.Body.Close()
+	}
+	// First attempt uses the original body.
+	if bodyBytes != nil {
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	}
+	return retry.Do(c.HTTPClient, func() (*http.Request, error) {
+		var body io.Reader
+		if bodyBytes != nil {
+			body = bytes.NewReader(bodyBytes)
+		}
+		r, err := http.NewRequestWithContext(req.Context(), method, url, body)
+		if err != nil {
+			return nil, err
+		}
+		r.Header = headers.Clone()
+		return r, nil
+	}, c.MaxRetries)
 }
 
 // Ask routes a question to the appropriate CA endpoint based on source type.
@@ -137,7 +171,7 @@ func (c *Client) askChat(ctx context.Context, token string, profile *profiles.Pr
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-server-timeout", "300")
 
-	resp, err := c.HTTPClient.Do(req)
+	resp, err := c.do(req)
 	if err != nil {
 		return nil, fmt.Errorf("chat API request failed: %w", err)
 	}
@@ -202,7 +236,7 @@ func (c *Client) askQueryData(ctx context.Context, token string, profile *profil
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-server-timeout", "300")
 
-	resp, err := c.HTTPClient.Do(req)
+	resp, err := c.do(req)
 	if err != nil {
 		return nil, fmt.Errorf("queryData API request failed: %w", err)
 	}
@@ -277,7 +311,7 @@ func (c *Client) AskQueryDataRaw(ctx context.Context, token string, profile *pro
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := c.HTTPClient.Do(req)
+	resp, err := c.do(req)
 	if err != nil {
 		return nil, fmt.Errorf("queryData API request failed: %w", err)
 	}
@@ -347,7 +381,7 @@ func (c *Client) CreateAgent(ctx context.Context, token, projectID, _ string, op
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("x-server-timeout", "300")
 
-	resp, err := c.HTTPClient.Do(httpReq)
+	resp, err := c.do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("create-agent API request failed: %w", err)
 	}
@@ -402,7 +436,7 @@ func (c *Client) ListAgents(ctx context.Context, token, projectID, _ string) (*A
 		httpReq.Header.Set("Authorization", "Bearer "+token)
 		httpReq.Header.Set("Accept", "application/json")
 
-		resp, err := c.HTTPClient.Do(httpReq)
+		resp, err := c.do(httpReq)
 		if err != nil {
 			return nil, fmt.Errorf("list-agents API request failed: %w", err)
 		}
@@ -481,7 +515,7 @@ func (c *Client) AddVerifiedQuery(ctx context.Context, token, projectID, _ strin
 	getReq.Header.Set("Authorization", "Bearer "+token)
 	getReq.Header.Set("Accept", "application/json")
 
-	getResp, err := c.HTTPClient.Do(getReq)
+	getResp, err := c.do(getReq)
 	if err != nil {
 		return nil, fmt.Errorf("get agent failed: %w", err)
 	}
@@ -544,7 +578,7 @@ func (c *Client) AddVerifiedQuery(ctx context.Context, token, projectID, _ strin
 	patchReq.Header.Set("Content-Type", "application/json")
 	patchReq.Header.Set("x-server-timeout", "300")
 
-	patchResp, err := c.HTTPClient.Do(patchReq)
+	patchResp, err := c.do(patchReq)
 	if err != nil {
 		return nil, fmt.Errorf("updateSync agent failed: %w", err)
 	}

--- a/internal/ca/client_test.go
+++ b/internal/ca/client_test.go
@@ -28,9 +28,9 @@ func TestSourceName(t *testing.T) {
 }
 
 func TestNewClient(t *testing.T) {
-	c := NewClient(nil)
+	c := NewClient(nil, 0)
 	if c.HTTPClient == nil {
-		t.Error("NewClient(nil) should set default HTTP client")
+		t.Error("NewClient(nil, 0) should set default HTTP client")
 	}
 }
 

--- a/internal/cli/bigquery.go
+++ b/internal/cli/bigquery.go
@@ -62,6 +62,7 @@ func (a *App) registerJobsQueryCommand() {
 				maxResults,
 				format,
 				a.Opts.OutputFields,
+				a.Opts.Retry,
 			)
 		},
 	}

--- a/internal/cli/bigquery.go
+++ b/internal/cli/bigquery.go
@@ -95,5 +95,6 @@ func (a *App) discoveryOpts() *discovery.CLIOpts {
 		CredentialsFile: &a.Opts.CredentialsFile,
 		DryRun:          &a.Opts.DryRun,
 		OutputFields:    &a.Opts.OutputFields,
+		Retry:           &a.Opts.Retry,
 	}
 }

--- a/internal/cli/ca.go
+++ b/internal/cli/ca.go
@@ -122,7 +122,7 @@ func (a *App) caAskCmd() *cobra.Command {
 				return nil
 			}
 
-			client := ca.NewClient(nil)
+			client := ca.NewClient(nil, a.Opts.Retry)
 
 			// Stream thinking steps to stderr for text format.
 			var cb ca.StreamCallback
@@ -218,7 +218,7 @@ func (a *App) caCreateAgentCmd() *cobra.Command {
 				opts.ExampleQueries = eqs
 			}
 
-			client := ca.NewClient(nil)
+			client := ca.NewClient(nil, a.Opts.Retry)
 			result, err := client.CreateAgent(ctx, tok.AccessToken, projectID, a.Opts.Location, opts)
 			if err != nil {
 				dcxerrors.EmitAPIError(err)
@@ -267,7 +267,7 @@ func (a *App) caListAgentsCmd() *cobra.Command {
 				return nil
 			}
 
-			client := ca.NewClient(nil)
+			client := ca.NewClient(nil, a.Opts.Retry)
 			result, err := client.ListAgents(ctx, tok.AccessToken, projectID, a.Opts.Location)
 			if err != nil {
 				dcxerrors.EmitAPIError(err)
@@ -323,7 +323,7 @@ func (a *App) caAddVerifiedQueryCmd() *cobra.Command {
 				return nil
 			}
 
-			client := ca.NewClient(nil)
+			client := ca.NewClient(nil, a.Opts.Retry)
 			result, err := client.AddVerifiedQuery(ctx, tok.AccessToken, projectID, a.Opts.Location, ca.PatchAgentOpts{
 				AgentName: agentName,
 				ExampleQueries: []ca.ExampleQuery{

--- a/internal/cli/datacloud_helpers.go
+++ b/internal/cli/datacloud_helpers.go
@@ -134,7 +134,7 @@ func (a *App) schemaDescribeRunE(profileName *string, sourceType profiles.Source
 			return nil
 		}
 
-		client := ca.NewClient(nil)
+		client := ca.NewClient(nil, a.Opts.Retry)
 		result, err := datacloud.SchemaDescribe(ctx, client, tok.AccessToken, profile)
 		if err != nil {
 			dcxerrors.EmitAPIError(err)
@@ -171,7 +171,7 @@ func (a *App) databasesListRunE(profileName *string, sourceType profiles.SourceT
 			return nil
 		}
 
-		client := ca.NewClient(nil)
+		client := ca.NewClient(nil, a.Opts.Retry)
 		result, err := datacloud.DatabasesList(ctx, client, tok.AccessToken, profile)
 		if err != nil {
 			dcxerrors.EmitAPIError(err)

--- a/internal/cli/looker.go
+++ b/internal/cli/looker.go
@@ -148,5 +148,5 @@ func (a *App) resolveLookerClient(ctx context.Context, profileName string) (*loo
 		return nil, err
 	}
 
-	return looker.NewClient(nil, profile.LookerInstanceURL, tok.AccessToken), nil
+	return looker.NewClient(nil, profile.LookerInstanceURL, tok.AccessToken, a.Opts.Retry), nil
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -22,6 +22,7 @@ type GlobalOpts struct {
 	CredentialsFile string
 	DryRun          bool
 	OutputFields    string
+	Retry           int
 }
 
 // App holds the assembled CLI application state.
@@ -57,6 +58,7 @@ Structured output, typed errors, and an MCP bridge for AI agents.`,
 	pf.StringVar(&opts.CredentialsFile, "credentials-file", "", "Path to service account JSON credentials file")
 	pf.BoolVar(&opts.DryRun, "dry-run", false, "Validate and show what would be sent without executing")
 	pf.StringVar(&opts.OutputFields, "output-fields", "", "Comma-separated list of fields to include in output (e.g., name,schema)")
+	pf.IntVar(&opts.Retry, "retry", 0, "Number of retries on 429/transport errors (0=no retry, 3=recommended)")
 
 	app := &App{
 		Root:     root,

--- a/internal/cli/spanner_ddl.go
+++ b/internal/cli/spanner_ddl.go
@@ -13,6 +13,7 @@ import (
 	"github.com/haiyuan-eng-google/dcx-cli/internal/auth"
 	"github.com/haiyuan-eng-google/dcx-cli/internal/contracts"
 	dcxerrors "github.com/haiyuan-eng-google/dcx-cli/internal/errors"
+	"github.com/haiyuan-eng-google/dcx-cli/internal/retry"
 	"github.com/spf13/cobra"
 )
 
@@ -133,16 +134,16 @@ Examples:
 				return nil
 			}
 
-			// Execute request.
-			req, err := http.NewRequestWithContext(ctx, "PATCH", apiURL, bytes.NewReader(bodyJSON))
-			if err != nil {
-				dcxerrors.Emit(dcxerrors.Internal, err.Error(), "")
-				return nil
-			}
-			req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
-			req.Header.Set("Content-Type", "application/json")
-
-			resp, err := http.DefaultClient.Do(req)
+			// Execute request with retry.
+			resp, err := retry.Do(nil, func() (*http.Request, error) {
+				r, err := http.NewRequestWithContext(ctx, "PATCH", apiURL, bytes.NewReader(bodyJSON))
+				if err != nil {
+					return nil, err
+				}
+				r.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+				r.Header.Set("Content-Type", "application/json")
+				return r, nil
+			}, a.Opts.Retry)
 			if err != nil {
 				dcxerrors.Emit(dcxerrors.InfraError, fmt.Sprintf("API request failed: %v", err), "")
 				return nil

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -136,6 +136,7 @@ func GlobalFlags() []FlagContract {
 		{Name: "token", Type: "string", Description: "Bearer access token (overrides all other auth)"},
 		{Name: "credentials-file", Type: "string", Description: "Path to service account JSON credentials file"},
 		{Name: "output-fields", Type: "string", Description: "Comma-separated list of fields to include in output"},
+		{Name: "retry", Type: "int", Description: "Number of retries on 429/transport errors (0=no retry)"},
 	}
 }
 

--- a/internal/discovery/executor.go
+++ b/internal/discovery/executor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/haiyuan-eng-google/dcx-cli/internal/auth"
 	dcxerrors "github.com/haiyuan-eng-google/dcx-cli/internal/errors"
 	"github.com/haiyuan-eng-google/dcx-cli/internal/output"
+	"github.com/haiyuan-eng-google/dcx-cli/internal/retry"
 )
 
 // ListEnvelope is the normalized output for list commands.
@@ -25,6 +26,7 @@ type ListEnvelope struct {
 type Executor struct {
 	HTTPClient   *http.Client
 	OutputFields string // comma-separated fields to include in output
+	MaxRetries   int    // 0 = no retry
 }
 
 // NewExecutor creates an Executor with the given HTTP client.
@@ -76,15 +78,14 @@ func (e *Executor) Execute(
 		return e.executePageAll(ctx, cmd, pathParams, queryParams, tok.AccessToken, format)
 	}
 
-	// 5. Build and execute request.
-	req, err := BuildRequest(cmd, pathParams, queryParams, tok.AccessToken, nil)
-	if err != nil {
-		dcxerrors.Emit(dcxerrors.Internal, fmt.Sprintf("building request: %v", err), "")
-		return nil
-	}
-	req = req.WithContext(ctx)
-
-	resp, err := e.HTTPClient.Do(req)
+	// 5. Build and execute request (with retry if configured).
+	resp, err := retry.Do(e.HTTPClient, func() (*http.Request, error) {
+		r, err := BuildRequest(cmd, pathParams, queryParams, tok.AccessToken, nil)
+		if err != nil {
+			return nil, err
+		}
+		return r.WithContext(ctx), nil
+	}, e.MaxRetries)
 	if err != nil {
 		dcxerrors.Emit(dcxerrors.InfraError, fmt.Sprintf("API request failed: %v", err), "Check network connectivity")
 		return nil
@@ -138,14 +139,14 @@ func (e *Executor) executePageAll(
 			params["pageToken"] = pageToken
 		}
 
-		req, err := BuildRequest(cmd, pathParams, params, token, nil)
-		if err != nil {
-			dcxerrors.Emit(dcxerrors.Internal, fmt.Sprintf("building request: %v", err), "")
-			return nil
-		}
-		req = req.WithContext(ctx)
-
-		resp, err := e.HTTPClient.Do(req)
+		paramsCopy := params // capture for closure
+		resp, err := retry.Do(e.HTTPClient, func() (*http.Request, error) {
+			r, err := BuildRequest(cmd, pathParams, paramsCopy, token, nil)
+			if err != nil {
+				return nil, err
+			}
+			return r.WithContext(ctx), nil
+		}, e.MaxRetries)
 		if err != nil {
 			dcxerrors.Emit(dcxerrors.InfraError, fmt.Sprintf("API request failed: %v", err), "")
 			return nil

--- a/internal/discovery/register.go
+++ b/internal/discovery/register.go
@@ -22,6 +22,7 @@ type CLIOpts struct {
 	CredentialsFile *string
 	DryRun          *bool
 	OutputFields    *string
+	Retry           *int
 }
 
 // RegisterCommands parses a Discovery Document and registers all allowed
@@ -140,6 +141,9 @@ func registerOneCommand(
 
 			if opts.OutputFields != nil {
 				executor.OutputFields = *opts.OutputFields
+			}
+			if opts.Retry != nil {
+				executor.MaxRetries = *opts.Retry
 			}
 
 			return executor.Execute(

--- a/internal/looker/client.go
+++ b/internal/looker/client.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	dcxerrors "github.com/haiyuan-eng-google/dcx-cli/internal/errors"
+	"github.com/haiyuan-eng-google/dcx-cli/internal/retry"
 )
 
 // Client provides access to the Looker Admin SDK.
@@ -20,19 +21,20 @@ type Client struct {
 	HTTPClient  *http.Client
 	InstanceURL string // e.g. "https://mycompany.looker.com"
 	Token       string // Bearer token (Google OAuth or Looker API key)
+	MaxRetries  int
 }
 
 // NewClient creates a Looker client.
-func NewClient(httpClient *http.Client, instanceURL, token string) *Client {
+func NewClient(httpClient *http.Client, instanceURL, token string, maxRetries int) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	// Normalize instance URL.
 	instanceURL = strings.TrimRight(instanceURL, "/")
 	return &Client{
 		HTTPClient:  httpClient,
 		InstanceURL: instanceURL,
 		Token:       token,
+		MaxRetries:  maxRetries,
 	}
 }
 
@@ -81,7 +83,7 @@ func (c *Client) ListExplores(ctx context.Context) (*ExploresListResult, error) 
 	}
 	c.setHeaders(req)
 
-	resp, err := c.HTTPClient.Do(req)
+	resp, err := retry.Do(c.HTTPClient, func() (*http.Request, error) { return req, nil }, c.MaxRetries)
 	if err != nil {
 		return nil, fmt.Errorf("Looker API request failed: %w", err)
 	}
@@ -141,7 +143,7 @@ func (c *Client) GetDashboard(ctx context.Context, dashboardID string) (*Dashboa
 	}
 	c.setHeaders(req)
 
-	resp, err := c.HTTPClient.Do(req)
+	resp, err := retry.Do(c.HTTPClient, func() (*http.Request, error) { return req, nil }, c.MaxRetries)
 	if err != nil {
 		return nil, fmt.Errorf("Looker API request failed: %w", err)
 	}

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,0 +1,114 @@
+// Package retry provides a shared HTTP retry helper with exponential backoff.
+//
+// Retries on:
+//   - 429 (rate limit): always, respects Retry-After header
+//   - 5xx: only for transport-level failures (connection reset, timeout)
+//     where the server may not have received the request
+//
+// Does NOT retry when the server returns a 5xx response body (request was
+// processed, outcome uncertain). This is an intentional divergence from
+// googleworkspace/cli which only retries 429 + connect/timeout.
+package retry
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"os"
+	"time"
+
+	dcxerrors "github.com/haiyuan-eng-google/dcx-cli/internal/errors"
+)
+
+const (
+	// MaxRetryDelay caps the sleep duration per attempt.
+	MaxRetryDelay = 60 * time.Second
+)
+
+// Do executes an HTTP request with retry logic. The buildRequest function
+// is called for each attempt to produce a fresh request (body readers may
+// be consumed on prior attempts).
+//
+// maxRetries=0 means no retries (single attempt). maxRetries=3 means up
+// to 4 total attempts.
+//
+// Returns the successful response, or the last error/response on exhaustion.
+func Do(client *http.Client, buildRequest func() (*http.Request, error), maxRetries int) (*http.Response, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	var lastResp *http.Response
+	var lastErr error
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		req, err := buildRequest()
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := client.Do(req)
+
+		// Transport error (connection reset, timeout, DNS failure).
+		if err != nil {
+			lastErr = err
+			if attempt < maxRetries {
+				delay := backoffDelay(attempt, "")
+				logRetry(attempt+1, maxRetries, delay, fmt.Sprintf("transport error: %v", err))
+				time.Sleep(delay)
+				continue
+			}
+			return nil, err
+		}
+
+		// 429: always retry, respect Retry-After.
+		if resp.StatusCode == http.StatusTooManyRequests {
+			lastResp = resp
+			if attempt < maxRetries {
+				retryAfter := resp.Header.Get("Retry-After")
+				delay := backoffDelay(attempt, retryAfter)
+				logRetry(attempt+1, maxRetries, delay, "rate limited (429)")
+				resp.Body.Close()
+				time.Sleep(delay)
+				continue
+			}
+			return resp, nil
+		}
+
+		// Success or non-retryable error.
+		return resp, nil
+	}
+
+	// Shouldn't reach here, but return last state.
+	if lastResp != nil {
+		return lastResp, nil
+	}
+	return nil, lastErr
+}
+
+// backoffDelay computes the retry delay. Uses Retry-After header if present,
+// otherwise exponential backoff (1s, 2s, 4s, ...). Capped at MaxRetryDelay.
+func backoffDelay(attempt int, retryAfterHeader string) time.Duration {
+	// Try Retry-After header first.
+	if seconds := dcxerrors.ParseRetryAfter(retryAfterHeader); seconds != nil {
+		delay := time.Duration(*seconds) * time.Second
+		if delay > MaxRetryDelay {
+			return MaxRetryDelay
+		}
+		return delay
+	}
+
+	// Exponential backoff: 1s, 2s, 4s, 8s, ...
+	secs := math.Pow(2, float64(attempt))
+	delay := time.Duration(secs) * time.Second
+	if delay > MaxRetryDelay {
+		return MaxRetryDelay
+	}
+	return delay
+}
+
+// logRetry prints a retry message to stderr (dim styling for TTY).
+func logRetry(attempt, maxRetries int, delay time.Duration, reason string) {
+	fmt.Fprintf(os.Stderr, "\033[2mretry %d/%d in %s: %s\033[0m\n",
+		attempt, maxRetries, delay.Round(time.Millisecond), reason)
+}

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -102,4 +102,3 @@ func backoffDelay(attempt int, retryAfterHeader string) time.Duration {
 	}
 	return delay
 }
-

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -11,10 +11,8 @@
 package retry
 
 import (
-	"fmt"
 	"math"
 	"net/http"
-	"os"
 	"time"
 
 	dcxerrors "github.com/haiyuan-eng-google/dcx-cli/internal/errors"
@@ -54,7 +52,6 @@ func Do(client *http.Client, buildRequest func() (*http.Request, error), maxRetr
 			lastErr = err
 			if attempt < maxRetries {
 				delay := backoffDelay(attempt, "")
-				logRetry(attempt+1, maxRetries, delay, fmt.Sprintf("transport error: %v", err))
 				time.Sleep(delay)
 				continue
 			}
@@ -67,7 +64,6 @@ func Do(client *http.Client, buildRequest func() (*http.Request, error), maxRetr
 			if attempt < maxRetries {
 				retryAfter := resp.Header.Get("Retry-After")
 				delay := backoffDelay(attempt, retryAfter)
-				logRetry(attempt+1, maxRetries, delay, "rate limited (429)")
 				resp.Body.Close()
 				time.Sleep(delay)
 				continue
@@ -107,8 +103,3 @@ func backoffDelay(attempt int, retryAfterHeader string) time.Duration {
 	return delay
 }
 
-// logRetry prints a retry message to stderr (dim styling for TTY).
-func logRetry(attempt, maxRetries int, delay time.Duration, reason string) {
-	fmt.Fprintf(os.Stderr, "\033[2mretry %d/%d in %s: %s\033[0m\n",
-		attempt, maxRetries, delay.Round(time.Millisecond), reason)
-}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -1,0 +1,216 @@
+package retry
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDo_NoRetry(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{"ok":true}`)
+	}))
+	defer server.Close()
+
+	resp, err := Do(nil, func() (*http.Request, error) {
+		return http.NewRequest("GET", server.URL, nil)
+	}, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
+func TestDo_Retries429(t *testing.T) {
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n <= 2 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(429)
+			return
+		}
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{"ok":true}`)
+	}))
+	defer server.Close()
+
+	start := time.Now()
+	resp, err := Do(nil, func() (*http.Request, error) {
+		return http.NewRequest("GET", server.URL, nil)
+	}, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	if atomic.LoadInt32(&attempts) != 3 {
+		t.Errorf("attempts = %d, want 3", attempts)
+	}
+	if time.Since(start) > 5*time.Second {
+		t.Error("retry took too long — Retry-After:0 should be near-instant")
+	}
+}
+
+func TestDo_ExhaustsRetries(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(429)
+	}))
+	defer server.Close()
+
+	resp, err := Do(nil, func() (*http.Request, error) {
+		return http.NewRequest("GET", server.URL, nil)
+	}, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should return the last 429 response when retries exhausted.
+	if resp.StatusCode != 429 {
+		t.Errorf("status = %d, want 429", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
+func TestDo_NoRetryOn400(t *testing.T) {
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(400)
+	}))
+	defer server.Close()
+
+	resp, err := Do(nil, func() (*http.Request, error) {
+		return http.NewRequest("GET", server.URL, nil)
+	}, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 400 {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	if atomic.LoadInt32(&attempts) != 1 {
+		t.Errorf("attempts = %d, want 1 (no retry on 400)", attempts)
+	}
+}
+
+func TestDo_NoRetryOn500Response(t *testing.T) {
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(500)
+		fmt.Fprint(w, `{"error":"internal"}`)
+	}))
+	defer server.Close()
+
+	resp, err := Do(nil, func() (*http.Request, error) {
+		return http.NewRequest("GET", server.URL, nil)
+	}, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 500 with a response body = server processed the request. No retry.
+	if resp.StatusCode != 500 {
+		t.Errorf("status = %d, want 500", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	if atomic.LoadInt32(&attempts) != 1 {
+		t.Errorf("attempts = %d, want 1 (no retry on 500 with body)", attempts)
+	}
+}
+
+func TestDo_ZeroRetries(t *testing.T) {
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(429)
+	}))
+	defer server.Close()
+
+	resp, err := Do(nil, func() (*http.Request, error) {
+		return http.NewRequest("GET", server.URL, nil)
+	}, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 429 {
+		t.Errorf("status = %d, want 429", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	if atomic.LoadInt32(&attempts) != 1 {
+		t.Errorf("attempts = %d, want 1 (no retries with maxRetries=0)", attempts)
+	}
+}
+
+func TestDo_RespectsRetryAfterHeader(t *testing.T) {
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(429)
+			return
+		}
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	start := time.Now()
+	resp, err := Do(nil, func() (*http.Request, error) {
+		return http.NewRequest("GET", server.URL, nil)
+	}, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	elapsed := time.Since(start)
+	if elapsed < 900*time.Millisecond {
+		t.Errorf("elapsed = %v, want >= 1s (Retry-After:1)", elapsed)
+	}
+}
+
+func TestBackoffDelay(t *testing.T) {
+	// No header: exponential.
+	if d := backoffDelay(0, ""); d != 1*time.Second {
+		t.Errorf("attempt 0 = %v, want 1s", d)
+	}
+	if d := backoffDelay(1, ""); d != 2*time.Second {
+		t.Errorf("attempt 1 = %v, want 2s", d)
+	}
+	if d := backoffDelay(2, ""); d != 4*time.Second {
+		t.Errorf("attempt 2 = %v, want 4s", d)
+	}
+
+	// With header: uses header value.
+	if d := backoffDelay(0, "5"); d != 5*time.Second {
+		t.Errorf("with Retry-After:5 = %v, want 5s", d)
+	}
+
+	// Header capped at MaxRetryDelay.
+	if d := backoffDelay(0, "120"); d != MaxRetryDelay {
+		t.Errorf("with Retry-After:120 = %v, want %v", d, MaxRetryDelay)
+	}
+
+	// Malformed header: falls back to exponential.
+	if d := backoffDelay(1, "invalid"); d != 2*time.Second {
+		t.Errorf("with invalid header = %v, want 2s", d)
+	}
+}


### PR DESCRIPTION
## Summary

Shared retry helper with exponential backoff for agent workflows. Inspired by googleworkspace/cli's `send_with_retry()` pattern, with intentional divergence on 5xx scope.

Partial close of #30 (item 1).

### Usage

```bash
# No retries (default, backwards compatible)
dcx datasets list --project-id=myproject

# Retry up to 3 times on 429/transport errors
dcx datasets list --project-id=myproject --retry=3
```

### Retry behavior

| Condition | Retry? | Notes |
|---|---|---|
| 429 (rate limit) | Yes | Respects `Retry-After` header |
| Transport error (connect/timeout) | Yes | Exponential backoff |
| 5xx with response body | No | Server processed request, outcome uncertain |
| 4xx (400, 404, etc.) | No | Client error, not transient |

### Backoff

| Attempt | Without Retry-After | With Retry-After: 5 |
|---|---|---|
| 1 | 1s | 5s |
| 2 | 2s | 5s |
| 3 | 4s | 5s |
| Cap | 60s max | 60s max |

### Design

- `internal/retry/retry.go`: shared helper, takes `buildRequest` closure for fresh requests per attempt
- Wired into Discovery executor (read + pageAll paths)
- `--retry` in `GlobalFlags()` — visible in `meta describe` and contracts
- MCP does NOT expose `--retry` (per issue #30 design: MCP clients should implement retry at their layer)

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes (8 new retry tests)
- [x] Retries 429 up to maxRetries, respects `Retry-After` timing
- [x] No retry on 400, 500 with body
- [x] `--retry=0` = single attempt (default, no change)
- [x] Exponential backoff: 1s, 2s, 4s, capped at 60s
- [x] `--retry` appears in `--help` and `meta describe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)