### PR TITLE
Add --page-limit and --page-delay for safe pagination (issue #30 item 3)

### DIFF
--- a/internal/discovery/executor.go
+++ b/internal/discovery/executor.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/haiyuan-eng-google/dcx-cli/internal/auth"
 	dcxerrors "github.com/haiyuan-eng-google/dcx-cli/internal/errors"
@@ -27,6 +28,8 @@ type Executor struct {
 	HTTPClient   *http.Client
 	OutputFields string // comma-separated fields to include in output
 	MaxRetries   int    // 0 = no retry
+	PageLimit    int    // max pages to fetch with --page-all (0 = unlimited)
+	PageDelayMs  int    // milliseconds between page fetches
 }
 
 // NewExecutor creates an Executor with the given HTTP client.
@@ -129,6 +132,7 @@ func (e *Executor) executePageAll(
 ) error {
 	var allItems []interface{}
 	pageToken := ""
+	pagesFetched := 0
 
 	for {
 		params := make(map[string]string, len(queryParams))
@@ -171,12 +175,31 @@ func (e *Executor) executePageAll(
 
 		items := extractItems(raw)
 		allItems = append(allItems, items...)
+		pagesFetched++
 
 		// Check for next page.
-		if npt, ok := raw["nextPageToken"].(string); ok && npt != "" {
-			pageToken = npt
-		} else {
+		npt, hasMore := raw["nextPageToken"].(string)
+		if !hasMore || npt == "" {
 			break
+		}
+
+		// Check page limit (0 = unlimited).
+		if e.PageLimit > 0 && pagesFetched >= e.PageLimit {
+			// Stopped by limit — include token so agents can continue.
+			allItems = injectResourceIDsForDomain(allItems, cmd.Method.Resource, cmd.Service.Domain)
+			envelope := ListEnvelope{
+				Items:         allItems,
+				Source:        sourceName(cmd.Service.Domain),
+				NextPageToken: npt,
+			}
+			return output.RenderFiltered(format, envelope, e.OutputFields)
+		}
+
+		pageToken = npt
+
+		// Delay between pages.
+		if e.PageDelayMs > 0 {
+			time.Sleep(time.Duration(e.PageDelayMs) * time.Millisecond)
 		}
 	}
 

--- a/internal/discovery/executor.go
+++ b/internal/discovery/executor.go
@@ -185,7 +185,10 @@ func (e *Executor) executePageAll(
 
 		// Check page limit (0 = unlimited).
 		if e.PageLimit > 0 && pagesFetched >= e.PageLimit {
-			// Stopped by limit — include token so agents can continue.
+			// Stopped by limit — include next_page_token so agents can
+			// continue with --page-token. The envelope only contains
+			// accumulated items + source + token; per-page API metadata
+			// (if any) is not preserved in the capped result.
 			allItems = injectResourceIDsForDomain(allItems, cmd.Method.Resource, cmd.Service.Domain)
 			envelope := ListEnvelope{
 				Items:         allItems,

--- a/internal/discovery/register.go
+++ b/internal/discovery/register.go
@@ -180,8 +180,8 @@ func registerOneCommand(
 	if cmd.Method.Action == "list" && methodSupportsPagination(cmd) {
 		leafCmd.Flags().StringVar(&pageToken, "page-token", "", "Page token for pagination")
 		leafCmd.Flags().BoolVar(&pageAll, "page-all", false, "Fetch all pages")
-		leafCmd.Flags().IntVar(&pageLimit, "page-limit", 10, "Max pages to fetch with --page-all (0=unlimited)")
-		leafCmd.Flags().IntVar(&pageDelayMs, "page-delay", 100, "Milliseconds between page fetches")
+		leafCmd.Flags().IntVar(&pageLimit, "page-limit", 10, "Max pages with --page-all (0=unlimited); ignored without --page-all")
+		leafCmd.Flags().IntVar(&pageDelayMs, "page-delay", 100, "Delay (ms) between pages with --page-all; ignored without --page-all")
 	}
 
 	// Add mutation-specific flags.
@@ -210,8 +210,8 @@ func registerOneCommand(
 		contractFlags = append(contractFlags,
 			contracts.FlagContract{Name: "page-token", Type: "string", Description: "Page token for pagination"},
 			contracts.FlagContract{Name: "page-all", Type: "bool", Description: "Fetch all pages"},
-			contracts.FlagContract{Name: "page-limit", Type: "int", Description: "Max pages to fetch with --page-all (0=unlimited)"},
-			contracts.FlagContract{Name: "page-delay", Type: "int", Description: "Milliseconds between page fetches"},
+			contracts.FlagContract{Name: "page-limit", Type: "int", Description: "Max pages with --page-all (0=unlimited); ignored without --page-all"},
+			contracts.FlagContract{Name: "page-delay", Type: "int", Description: "Delay (ms) between pages with --page-all; ignored without --page-all"},
 		)
 	}
 	if isMutation && cmd.Method.AcceptsBody() {

--- a/internal/discovery/register.go
+++ b/internal/discovery/register.go
@@ -90,6 +90,8 @@ func registerOneCommand(
 	boolFlagValues := make(map[string]*bool)
 	pageToken := ""
 	pageAll := false
+	pageLimit := 10
+	pageDelayMs := 100
 	bodyFlag := ""
 	forceFlag := false
 	isMutation := cmd.Method.IsMutation()
@@ -145,6 +147,8 @@ func registerOneCommand(
 			if opts.Retry != nil {
 				executor.MaxRetries = *opts.Retry
 			}
+			executor.PageLimit = pageLimit
+			executor.PageDelayMs = pageDelayMs
 
 			return executor.Execute(
 				context.Background(),
@@ -176,6 +180,8 @@ func registerOneCommand(
 	if cmd.Method.Action == "list" && methodSupportsPagination(cmd) {
 		leafCmd.Flags().StringVar(&pageToken, "page-token", "", "Page token for pagination")
 		leafCmd.Flags().BoolVar(&pageAll, "page-all", false, "Fetch all pages")
+		leafCmd.Flags().IntVar(&pageLimit, "page-limit", 10, "Max pages to fetch with --page-all (0=unlimited)")
+		leafCmd.Flags().IntVar(&pageDelayMs, "page-delay", 100, "Milliseconds between page fetches")
 	}
 
 	// Add mutation-specific flags.
@@ -204,6 +210,8 @@ func registerOneCommand(
 		contractFlags = append(contractFlags,
 			contracts.FlagContract{Name: "page-token", Type: "string", Description: "Page token for pagination"},
 			contracts.FlagContract{Name: "page-all", Type: "bool", Description: "Fetch all pages"},
+			contracts.FlagContract{Name: "page-limit", Type: "int", Description: "Max pages to fetch with --page-all (0=unlimited)"},
+			contracts.FlagContract{Name: "page-delay", Type: "int", Description: "Milliseconds between page fetches"},
 		)
 	}
 	if isMutation && cmd.Method.AcceptsBody() {


### PR DESCRIPTION
## Summary

Safe pagination defaults inspired by googleworkspace/cli. Prevents runaway fetches by default.

Partial close of #30 (item 3).

### Flags

| Flag | Default | Description |
|---|---|---|
| `--page-limit` | 10 | Max pages to fetch with `--page-all`. 0 = unlimited |
| `--page-delay` | 100 | Milliseconds between page fetches |

### Behavior

```bash
# Default: fetches up to 10 pages, 100ms delay between each
dcx jobs list --project-id=P --page-all

# Explicit limit: stop after 2 pages, include next_page_token for continuation
dcx jobs list --project-id=P --page-all --page-limit=2

# Unlimited (opt-in, explicit)
dcx datasets list --project-id=P --page-all --page-limit=0
```

When stopped by `--page-limit`, the output includes `next_page_token` so agents can continue with `--page-token`:
```json
{"items":[...], "source":"BigQuery", "next_page_token":"ABC123"}
```

### Verified

- `--page-all` default: 500 items (10 pages × 50), `next_page_token` present
- `--page-limit=2`: 100 items (2 pages), `next_page_token` present
- `--page-limit=0`: 34 items (all), no `next_page_token`
- Flags in `--help`, `meta describe`, and contracts

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes
- [x] Default 10-page limit works
- [x] `--page-limit=0` fetches all pages
- [x] Stopped-by-limit output includes `next_page_token`
- [x] Flags registered in contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)