### PR TITLE
Add meta schema for request/response schema introspection (issue #30 item 2)

### DIFF
--- a/assets/loader.go
+++ b/assets/loader.go
@@ -1,0 +1,21 @@
+package assets
+
+import "fmt"
+
+// DiscoveryDocForDomain returns the embedded Discovery doc bytes for a dcx domain.
+func DiscoveryDocForDomain(domain string) ([]byte, error) {
+	switch domain {
+	case "bigquery":
+		return BigQueryDiscovery, nil
+	case "spanner":
+		return SpannerDiscovery, nil
+	case "alloydb":
+		return AlloyDBDiscovery, nil
+	case "cloudsql":
+		return CloudSQLDiscovery, nil
+	case "looker":
+		return LookerDiscovery, nil
+	default:
+		return nil, fmt.Errorf("no Discovery doc for domain %q", domain)
+	}
+}

--- a/internal/cli/meta.go
+++ b/internal/cli/meta.go
@@ -1,8 +1,12 @@
 package cli
 
 import (
+	"fmt"
 	"strings"
 
+	"github.com/haiyuan-eng-google/dcx-cli/assets"
+	"github.com/haiyuan-eng-google/dcx-cli/internal/contracts"
+	"github.com/haiyuan-eng-google/dcx-cli/internal/discovery"
 	dcxerrors "github.com/haiyuan-eng-google/dcx-cli/internal/errors"
 	"github.com/haiyuan-eng-google/dcx-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -16,6 +20,7 @@ func (a *App) addMetaCommands() {
 
 	metaCmd.AddCommand(a.metaCommandsCmd())
 	metaCmd.AddCommand(a.metaDescribeCmd())
+	metaCmd.AddCommand(a.metaSchemaCmd())
 
 	a.Root.AddCommand(metaCmd)
 }
@@ -88,4 +93,183 @@ func (a *App) metaDescribeCmd() *cobra.Command {
 			}
 		},
 	}
+}
+
+func (a *App) metaSchemaCmd() *cobra.Command {
+	var resolveRefs bool
+
+	cmd := &cobra.Command{
+		Use:   "schema [command...] or [service.TypeName]",
+		Short: "Show request/response schema for a command or type",
+		Long: `Show the JSON schema for a command's request/response body, or
+look up a specific schema type from a Discovery document.
+
+Method lookup:
+  dcx meta schema datasets insert
+  dcx meta schema spanner databases create
+
+Type lookup:
+  dcx meta schema bigquery.Dataset
+  dcx meta schema spanner.CreateDatabaseRequest
+
+Use --resolve-refs to expand $ref pointers inline.`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			formatVal, err := a.OutputFormat()
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.InvalidConfig, err.Error(), "")
+				return nil
+			}
+
+			// Type lookup: single arg with a dot (e.g., "bigquery.Dataset").
+			if len(args) == 1 && strings.Contains(args[0], ".") {
+				return a.schemaTypeLookup(args[0], resolveRefs, formatVal)
+			}
+
+			// Method lookup: command path (e.g., "datasets insert").
+			return a.schemaMethodLookup(args, resolveRefs, formatVal)
+		},
+	}
+
+	cmd.Flags().BoolVar(&resolveRefs, "resolve-refs", false, "Expand $ref pointers inline")
+
+	a.Registry.Register(contracts.BuildContract(
+		"meta schema", "meta",
+		"Show request/response schema for a command or type",
+		[]contracts.FlagContract{
+			{Name: "resolve-refs", Type: "bool", Description: "Expand $ref pointers inline"},
+		},
+		false, false,
+	))
+
+	return cmd
+}
+
+func (a *App) schemaMethodLookup(args []string, resolveRefs bool, format output.Format) error {
+	commandPath := strings.Join(args, " ")
+
+	// Find the command in the registry to get the domain.
+	contract, err := a.Registry.Describe(commandPath)
+	if err != nil {
+		dcxerrors.Emit(dcxerrors.UnknownCommand, err.Error(), "Run 'dcx meta commands' to see available commands")
+		return nil
+	}
+
+	// Load Discovery doc for this domain.
+	docJSON, err := assets.DiscoveryDocForDomain(contract.Domain)
+	if err != nil {
+		dcxerrors.Emit(dcxerrors.InvalidConfig,
+			fmt.Sprintf("no schema available for domain %q (not Discovery-driven)", contract.Domain),
+			"Schema lookup is supported for Discovery-driven commands only")
+		return nil
+	}
+
+	// Parse the doc to find the matching GeneratedCommand.
+	svc := discovery.ConfigForDomain(contract.Domain)
+	if svc == nil {
+		dcxerrors.Emit(dcxerrors.InvalidConfig, fmt.Sprintf("no service config for domain %q", contract.Domain), "")
+		return nil
+	}
+
+	commands, err := discovery.Parse(docJSON, svc)
+	if err != nil {
+		dcxerrors.Emit(dcxerrors.Internal, fmt.Sprintf("parsing Discovery doc: %v", err), "")
+		return nil
+	}
+
+	var matched *discovery.GeneratedCommand
+	for i := range commands {
+		if commands[i].CommandPath == commandPath {
+			matched = &commands[i]
+			break
+		}
+	}
+	if matched == nil {
+		dcxerrors.Emit(dcxerrors.UnknownCommand,
+			fmt.Sprintf("command %q not found in Discovery doc for %s", commandPath, contract.Domain), "")
+		return nil
+	}
+
+	// Extract schemas from the doc.
+	schemas, err := discovery.ExtractSchemas(docJSON)
+	if err != nil {
+		dcxerrors.Emit(dcxerrors.Internal, fmt.Sprintf("extracting schemas: %v", err), "")
+		return nil
+	}
+
+	// Build result.
+	result := map[string]interface{}{
+		"command": contract.Command,
+		"domain":  contract.Domain,
+	}
+
+	if matched.Method.RequestRef != "" {
+		result["request_schema"] = matched.Method.RequestRef
+		if schema, ok := schemas[matched.Method.RequestRef]; ok {
+			if resolveRefs {
+				schema = discovery.ResolveRefs(schema, schemas)
+			}
+			result["request"] = schema
+		}
+	} else {
+		result["request_schema"] = nil
+	}
+
+	if matched.Method.ResponseRef != "" {
+		result["response_schema"] = matched.Method.ResponseRef
+		if schema, ok := schemas[matched.Method.ResponseRef]; ok {
+			if resolveRefs {
+				schema = discovery.ResolveRefs(schema, schemas)
+			}
+			result["response"] = schema
+		}
+	} else {
+		result["response_schema"] = nil
+	}
+
+	return a.Render(format, result)
+}
+
+func (a *App) schemaTypeLookup(path string, resolveRefs bool, format output.Format) error {
+	parts := strings.SplitN(path, ".", 2)
+	if len(parts) != 2 {
+		dcxerrors.Emit(dcxerrors.InvalidConfig, "type lookup format: service.TypeName (e.g., bigquery.Dataset)", "")
+		return nil
+	}
+
+	domain := parts[0]
+	typeName := parts[1]
+
+	docJSON, err := assets.DiscoveryDocForDomain(domain)
+	if err != nil {
+		dcxerrors.Emit(dcxerrors.InvalidConfig,
+			fmt.Sprintf("no Discovery doc for domain %q", domain),
+			"Type lookup is supported for Discovery-driven domains: bigquery, spanner, alloydb, cloudsql, looker")
+		return nil
+	}
+
+	schemas, err := discovery.ExtractSchemas(docJSON)
+	if err != nil {
+		dcxerrors.Emit(dcxerrors.Internal, fmt.Sprintf("extracting schemas: %v", err), "")
+		return nil
+	}
+
+	schema, ok := schemas[typeName]
+	if !ok {
+		dcxerrors.Emit(dcxerrors.NotFound,
+			fmt.Sprintf("schema %q not found in %s Discovery doc", typeName, domain), "")
+		return nil
+	}
+
+	if resolveRefs {
+		schema = discovery.ResolveRefs(schema, schemas)
+	}
+
+	result := map[string]interface{}{
+		"schema_name": typeName,
+		"service":     domain,
+		"schema":      schema,
+	}
+
+	return a.Render(format, result)
 }

--- a/internal/cli/meta.go
+++ b/internal/cli/meta.go
@@ -148,6 +148,10 @@ Use --resolve-refs to expand $ref pointers inline.`,
 func (a *App) schemaMethodLookup(args []string, resolveRefs bool, format output.Format) error {
 	commandPath := strings.Join(args, " ")
 
+	// Strip optional "dcx " prefix so both "datasets insert" and
+	// "dcx datasets insert" (copied from meta commands output) work.
+	commandPath = strings.TrimPrefix(commandPath, "dcx ")
+
 	// Find the command in the registry to get the domain.
 	contract, err := a.Registry.Describe(commandPath)
 	if err != nil {
@@ -185,8 +189,10 @@ func (a *App) schemaMethodLookup(args []string, resolveRefs bool, format output.
 		}
 	}
 	if matched == nil {
-		dcxerrors.Emit(dcxerrors.UnknownCommand,
-			fmt.Sprintf("command %q not found in Discovery doc for %s", commandPath, contract.Domain), "")
+		// Command exists in registry but not in Discovery doc — it's a static command.
+		dcxerrors.Emit(dcxerrors.InvalidConfig,
+			fmt.Sprintf("command %q is not Discovery-driven; schema introspection is not available", commandPath),
+			"Schema lookup is supported for Discovery-generated commands only")
 		return nil
 	}
 

--- a/internal/discovery/model.go
+++ b/internal/discovery/model.go
@@ -56,7 +56,8 @@ type ApiMethod struct {
 	FlatPath       string              `json:"flatPath"`   // Simplified path template
 	Parameters     map[string]ApiParam `json:"parameters"`
 	ParameterOrder []string            `json:"parameterOrder"`
-	RequestRef     string              `json:"requestRef,omitempty"` // Schema $ref for request body (e.g. "Dataset")
+	RequestRef     string              `json:"requestRef,omitempty"`  // Schema $ref for request body (e.g. "Dataset")
+	ResponseRef    string              `json:"responseRef,omitempty"` // Schema $ref for response body
 }
 
 // IsMutation returns true if the method modifies state (non-GET).

--- a/internal/discovery/parser.go
+++ b/internal/discovery/parser.go
@@ -28,6 +28,7 @@ type discoveryMethod struct {
 	Parameters     map[string]discoveryParam `json:"parameters"`
 	ParameterOrder []string                  `json:"parameterOrder"`
 	Request        *discoveryRef             `json:"request,omitempty"`
+	Response       *discoveryRef             `json:"response,omitempty"`
 }
 
 type discoveryRef struct {
@@ -85,9 +86,12 @@ func extractMethods(
 				continue
 			}
 
-			var requestRef string
+			var requestRef, responseRef string
 			if method.Request != nil {
 				requestRef = method.Request.Ref
+			}
+			if method.Response != nil {
+				responseRef = method.Response.Ref
 			}
 
 			apiMethod := ApiMethod{
@@ -101,6 +105,7 @@ func extractMethods(
 				Parameters:     convertParams(method.Parameters),
 				ParameterOrder: method.ParameterOrder,
 				RequestRef:     requestRef,
+				ResponseRef:    responseRef,
 			}
 
 			// Build command path.

--- a/internal/discovery/schema.go
+++ b/internal/discovery/schema.go
@@ -1,0 +1,75 @@
+package discovery
+
+import "encoding/json"
+
+// ExtractSchemas parses the schemas section from a raw Discovery doc.
+func ExtractSchemas(docJSON []byte) (map[string]interface{}, error) {
+	var doc struct {
+		Schemas map[string]interface{} `json:"schemas"`
+	}
+	if err := json.Unmarshal(docJSON, &doc); err != nil {
+		return nil, err
+	}
+	if doc.Schemas == nil {
+		doc.Schemas = make(map[string]interface{})
+	}
+	return doc.Schemas, nil
+}
+
+// ResolveRefs recursively expands {"$ref": "TypeName"} objects in a schema
+// tree using the provided schemas map. Uses a seen set for cycle detection.
+func ResolveRefs(value interface{}, schemas map[string]interface{}) interface{} {
+	seen := make(map[string]bool)
+	return resolveRefsRecursive(value, schemas, seen)
+}
+
+func resolveRefsRecursive(value interface{}, schemas map[string]interface{}, seen map[string]bool) interface{} {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		// Check for objects containing "$ref" — expand the referenced schema
+		// and merge any sibling fields (like "description") into the result.
+		if ref, ok := v["$ref"].(string); ok {
+			if seen[ref] {
+				return map[string]interface{}{"$ref": ref, "_circular": true}
+			}
+			if schema, ok := schemas[ref]; ok {
+				seen[ref] = true
+				resolved := resolveRefsRecursive(schema, schemas, seen)
+				delete(seen, ref)
+
+				// Merge sibling fields (e.g., description) into resolved schema.
+				if resolvedMap, ok := resolved.(map[string]interface{}); ok {
+					merged := make(map[string]interface{}, len(resolvedMap)+len(v))
+					for k, val := range resolvedMap {
+						merged[k] = val
+					}
+					for k, val := range v {
+						if k != "$ref" {
+							merged[k] = val
+						}
+					}
+					return merged
+				}
+				return resolved
+			}
+			return v
+		}
+
+		// Recurse into all values.
+		result := make(map[string]interface{}, len(v))
+		for k, val := range v {
+			result[k] = resolveRefsRecursive(val, schemas, seen)
+		}
+		return result
+
+	case []interface{}:
+		result := make([]interface{}, len(v))
+		for i, val := range v {
+			result[i] = resolveRefsRecursive(val, schemas, seen)
+		}
+		return result
+
+	default:
+		return value
+	}
+}

--- a/internal/discovery/services.go
+++ b/internal/discovery/services.go
@@ -1,5 +1,23 @@
 package discovery
 
+// ConfigForDomain returns the ServiceConfig for a dcx domain name.
+func ConfigForDomain(domain string) *ServiceConfig {
+	switch domain {
+	case "bigquery":
+		return BigQueryConfig()
+	case "spanner":
+		return SpannerConfig()
+	case "alloydb":
+		return AlloyDBConfig()
+	case "cloudsql":
+		return CloudSQLConfig()
+	case "looker":
+		return LookerConfig()
+	default:
+		return nil
+	}
+}
+
 // BigQueryConfig returns the ServiceConfig for BigQuery dynamic commands.
 func BigQueryConfig() *ServiceConfig {
 	return &ServiceConfig{

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -139,6 +139,7 @@ func TestCommandDiscovery(t *testing.T) {
 		"dcx profiles list", "dcx profiles validate", "dcx profiles test",
 		// Meta
 		"dcx meta commands", "dcx meta describe", "dcx meta generate-skills",
+		"dcx meta schema",
 		// MCP
 		"dcx mcp serve",
 		// Completion
@@ -156,8 +157,8 @@ func TestCommandDiscovery(t *testing.T) {
 		}
 	}
 
-	if len(commands) < 84 {
-		t.Errorf("expected at least 84 commands, got %d", len(commands))
+	if len(commands) < 85 {
+		t.Errorf("expected at least 85 commands, got %d", len(commands))
 	}
 }
 


### PR DESCRIPTION
## Summary

Agents can now inspect the JSON schema for any Discovery command's request/response body before constructing `--body` payloads (84 → 85 commands).

Partial close of #30 (item 2).

### Usage

```bash
# Method lookup: what JSON shape does datasets insert expect?
dcx meta schema datasets insert
# → request_schema: "Dataset", response_schema: "Dataset", properties: [...]

# Type lookup: show a specific schema type
dcx meta schema bigquery.DatasetReference
# → {datasetId: string, projectId: string}

# Expand $ref pointers inline
dcx meta schema datasets insert --resolve-refs
# → datasetReference expanded from {"$ref":"DatasetReference"} to full object
```

### Design

Per plan review feedback:
1. **Uses `discovery.Parse()` + `GeneratedCommand` match** for method lookup — no raw Discovery tree walking
2. **`ResponseRef` added to `ApiMethod`** — parser now extracts `response.$ref`
3. **Shared `assets.DiscoveryDocForDomain()`** — maps domain names to embedded docs
4. **Generic recursive ref resolution** — handles `$ref` in properties, items, additionalProperties, any position. Merges sibling fields (description alongside $ref). Cycle detection via seen set.

### Output shape

Method lookup:
```json
{"command":"dcx datasets insert", "domain":"bigquery", "request_schema":"Dataset", "request":{...}, "response_schema":"Dataset", "response":{...}}
```

Type lookup:
```json
{"schema_name":"DatasetReference", "service":"bigquery", "schema":{...}}
```

### Scope

- Discovery-driven commands: full support
- Non-Discovery domains (ca, auth, profiles): `INVALID_CONFIG` error
- Unknown types: `NOT_FOUND` error

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes
- [x] Method lookup: `datasets insert` shows request + response schemas
- [x] Method lookup: `datasets get` shows response only (no request body)
- [x] Type lookup: `bigquery.DatasetReference` shows type schema
- [x] `--resolve-refs` expands $ref with sibling field preservation
- [x] Non-Discovery domain: structured error
- [x] Unknown type: NOT_FOUND error

🤖 Generated with [Claude Code](https://claude.com/claude-code)