### PR TITLE
Add workflow recipes to generated skills

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/olekukonko/errors v1.2.0 // indirect
 	github.com/olekukonko/ll v0.1.6 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/olekukonko/tablewriter v1.1.4 h1:ORUMI3dXbMnRlRggJX3+q7OzQFDdvgbN9nVWj1drm6I=
 github.com/olekukonko/tablewriter v1.1.4/go.mod h1:+kedxuyTtgoZLwif3P1Em4hARJs+mVnzKxmsCL/C5RY=
+github.com/pelletier/go-toml/v2 v2.3.0 h1:k59bC/lIZREW0/iVaQR8nDHxVq8OVlIzYCOJf421CaM=
+github.com/pelletier/go-toml/v2 v2.3.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=

--- a/internal/cli/generate_skills.go
+++ b/internal/cli/generate_skills.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/haiyuan-eng-google/dcx-cli/internal/contracts"
 	dcxerrors "github.com/haiyuan-eng-google/dcx-cli/internal/errors"
+	"github.com/haiyuan-eng-google/dcx-cli/recipes"
 	"github.com/spf13/cobra"
 )
 
@@ -32,8 +33,9 @@ func (a *App) addGenerateSkillsCommand() {
 		Use:   "generate-skills",
 		Short: "Generate SKILL.md files from the command contract registry",
 		Long: `Generate SKILL.md files for each domain from the machine-readable
-contract registry. Each skill file includes command routing tables,
-flag details, and decision rules derived from the live contracts.
+contract registry and the embedded workflow recipe registry. Each skill
+file includes command routing tables, workflow recipes, flag details, and
+decision rules derived from the live contracts.
 
 By default writes to stdout. Use --out-dir to write files to a directory.`,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
@@ -45,6 +47,11 @@ By default writes to stdout. Use --out-dir to write files to a directory.`,
 
 			// Group by domain.
 			byDomain := groupByDomain(all)
+			allRecipes, err := recipes.Load()
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.Internal, fmt.Sprintf("loading recipes: %v", err), "")
+				return nil
+			}
 
 			// Filter domains if specified.
 			if len(domains) > 0 {
@@ -63,12 +70,12 @@ By default writes to stdout. Use --out-dir to write files to a directory.`,
 			}
 
 			if outDir != "" {
-				return writeSkillFiles(byDomain, outDir)
+				return writeSkillFiles(byDomain, allRecipes, outDir)
 			}
 
 			// Write to stdout.
 			for _, domain := range sortedDomainKeys(byDomain) {
-				content := renderSkill(domain, byDomain[domain])
+				content := renderSkill(domain, byDomain[domain], recipes.ForDomain(allRecipes, domain))
 				fmt.Println(content)
 				fmt.Println("---")
 			}
@@ -113,9 +120,9 @@ func sortedDomainKeys(m map[string][]*contracts.CommandContract) []string {
 	return keys
 }
 
-func writeSkillFiles(byDomain map[string][]*contracts.CommandContract, outDir string) error {
+func writeSkillFiles(byDomain map[string][]*contracts.CommandContract, allRecipes []recipes.Recipe, outDir string) error {
 	for _, domain := range sortedDomainKeys(byDomain) {
-		content := renderSkill(domain, byDomain[domain])
+		content := renderSkill(domain, byDomain[domain], recipes.ForDomain(allRecipes, domain))
 		dir := filepath.Join(outDir, "dcx-"+domain)
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return fmt.Errorf("creating directory %s: %w", dir, err)
@@ -129,7 +136,7 @@ func writeSkillFiles(byDomain map[string][]*contracts.CommandContract, outDir st
 	return nil
 }
 
-func renderSkill(domain string, cmds []*contracts.CommandContract) string {
+func renderSkill(domain string, cmds []*contracts.CommandContract, domainRecipes []recipes.Recipe) string {
 	var b strings.Builder
 
 	domainTitle := domainDisplayName(domain)
@@ -187,6 +194,25 @@ func renderSkill(domain string, cmds []*contracts.CommandContract) string {
 		}
 		if hasDryRun {
 			b.WriteString("Mutations marked with `--dry-run` support previewing the request without executing.\n\n")
+		}
+	}
+
+	if len(domainRecipes) > 0 {
+		b.WriteString("## Workflows\n\n")
+		for _, recipe := range domainRecipes {
+			b.WriteString(fmt.Sprintf("### %s\n\n", recipe.Title))
+			b.WriteString(recipe.Description)
+			b.WriteString("\n\n")
+			for i, step := range recipe.Steps {
+				b.WriteString(fmt.Sprintf("%d. `%s`\n", i+1, step))
+			}
+			if len(recipe.Cautions) > 0 {
+				b.WriteString("\nCautions:\n")
+				for _, caution := range recipe.Cautions {
+					b.WriteString(fmt.Sprintf("- %s\n", caution))
+				}
+			}
+			b.WriteString("\n")
 		}
 	}
 

--- a/internal/cli/generate_skills_test.go
+++ b/internal/cli/generate_skills_test.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/haiyuan-eng-google/dcx-cli/internal/contracts"
+	"github.com/haiyuan-eng-google/dcx-cli/recipes"
+)
+
+func TestRenderSkillEmbedsWorkflows(t *testing.T) {
+	cmds := []*contracts.CommandContract{
+		contracts.BuildContract("datasets list", "bigquery", "List datasets", nil, false, false),
+		contracts.BuildContract("tables get", "bigquery", "Get table", []contracts.FlagContract{
+			{Name: "table-id", Type: "string", Description: "Table ID", Required: true},
+		}, false, false),
+	}
+	domainRecipes := []recipes.Recipe{{
+		Name:        "bigquery-table-inventory",
+		Title:       "Inventory and inspect BigQuery tables",
+		Description: "List datasets and inspect a table.",
+		Services:    []string{"bigquery"},
+		Steps: []string{
+			"dcx datasets list --project-id $PROJECT_ID --format json",
+			"dcx tables get --project-id $PROJECT_ID --dataset-id $DATASET_ID --table-id $TABLE_ID --format json",
+		},
+		Cautions: []string{"Keep output bounded."},
+	}}
+
+	rendered := renderSkill("bigquery", cmds, domainRecipes)
+	for _, want := range []string{
+		"## Workflows",
+		"### Inventory and inspect BigQuery tables",
+		"1. `dcx datasets list --project-id $PROJECT_ID --format json`",
+		"Cautions:",
+		"## Flag reference",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered skill missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestEmbeddedRecipeStepsReferenceRegisteredCommands(t *testing.T) {
+	app := NewApp()
+	allRecipes, err := recipes.Load()
+	if err != nil {
+		t.Fatalf("recipes.Load: %v", err)
+	}
+
+	for _, recipe := range allRecipes {
+		for _, step := range recipe.Steps {
+			contract, args, ok := stepContractAndArgs(app, step)
+			if !ok {
+				t.Fatalf("recipe %s step does not reference a registered command: %s", recipe.Name, step)
+			}
+			if err := validateStepFlags(contract, args); err != nil {
+				t.Fatalf("recipe %s step has invalid flags: %v\nstep: %s", recipe.Name, err, step)
+			}
+		}
+	}
+}
+
+func stepContractAndArgs(app *App, step string) (*contracts.CommandContract, []string, bool) {
+	parts := strings.Fields(step)
+	for i := len(parts); i >= 2; i-- {
+		candidate := strings.Join(parts[:i], " ")
+		if contract, ok := app.Registry.Get(candidate); ok {
+			return contract, parts[i:], true
+		}
+	}
+	return nil, nil, false
+}
+
+func validateStepFlags(contract *contracts.CommandContract, args []string) error {
+	allowed := make(map[string]bool, len(contract.Flags))
+	for _, flag := range contract.Flags {
+		allowed[flag.Name] = true
+	}
+	if contract.SupportsDryRun {
+		allowed["dry-run"] = true
+	}
+
+	for _, arg := range args {
+		if !strings.HasPrefix(arg, "--") {
+			continue
+		}
+		name := strings.TrimPrefix(arg, "--")
+		if before, _, ok := strings.Cut(name, "="); ok {
+			name = before
+		}
+		if name == "" {
+			continue
+		}
+		if !allowed[name] {
+			return fmt.Errorf("%s does not define --%s", contract.Command, name)
+		}
+	}
+	return nil
+}

--- a/recipes/registry.go
+++ b/recipes/registry.go
@@ -1,0 +1,117 @@
+// Package recipes stores workflow recipes embedded into generated skills.
+package recipes
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+//go:embed *.toml
+var registryFS embed.FS
+
+// Recipe is a TOML-defined workflow recipe that can be embedded into one or
+// more domain SKILL.md files.
+type Recipe struct {
+	Name        string   `toml:"name"`
+	Title       string   `toml:"title"`
+	Description string   `toml:"description"`
+	Services    []string `toml:"services"`
+	Steps       []string `toml:"steps"`
+	Cautions    []string `toml:"cautions"`
+}
+
+// Load returns every embedded recipe, sorted by name.
+func Load() ([]Recipe, error) {
+	return LoadFS(registryFS, ".")
+}
+
+// LoadFS loads recipe definitions from all *.toml files in dir.
+func LoadFS(fsys fs.FS, dir string) ([]Recipe, error) {
+	entries, err := fs.ReadDir(fsys, dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading recipes: %w", err)
+	}
+
+	var all []Recipe
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".toml") {
+			continue
+		}
+		path := entry.Name()
+		if dir != "." {
+			path = dir + "/" + entry.Name()
+		}
+		data, err := fs.ReadFile(fsys, path)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", path, err)
+		}
+		parsed, err := decodeRecipes(path, data)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, parsed...)
+	}
+
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Name < all[j].Name
+	})
+	return all, nil
+}
+
+// ForDomain returns recipes that declare the given service/domain.
+func ForDomain(all []Recipe, domain string) []Recipe {
+	var result []Recipe
+	for _, recipe := range all {
+		for _, service := range recipe.Services {
+			if service == domain {
+				result = append(result, recipe)
+				break
+			}
+		}
+	}
+	return result
+}
+
+func decodeRecipes(path string, data []byte) ([]Recipe, error) {
+	var file struct {
+		Recipes []Recipe `toml:"recipes"`
+	}
+	if err := toml.Unmarshal(data, &file); err != nil {
+		return nil, fmt.Errorf("%s: parsing TOML: %w", path, err)
+	}
+	if len(file.Recipes) == 0 {
+		return nil, fmt.Errorf("%s: no recipes found", path)
+	}
+	for i, recipe := range file.Recipes {
+		if err := validateRecipe(recipe); err != nil {
+			return nil, fmt.Errorf("%s: recipe %d: %w", path, i+1, err)
+		}
+	}
+	return file.Recipes, nil
+}
+
+func validateRecipe(recipe Recipe) error {
+	switch {
+	case strings.TrimSpace(recipe.Name) == "":
+		return fmt.Errorf("recipe missing name")
+	case strings.TrimSpace(recipe.Title) == "":
+		return fmt.Errorf("recipe %q missing title", recipe.Name)
+	case strings.TrimSpace(recipe.Description) == "":
+		return fmt.Errorf("recipe %q missing description", recipe.Name)
+	case len(recipe.Services) == 0:
+		return fmt.Errorf("recipe %q missing services", recipe.Name)
+	case len(recipe.Steps) == 0:
+		return fmt.Errorf("recipe %q missing steps", recipe.Name)
+	}
+	for _, step := range recipe.Steps {
+		if !strings.HasPrefix(step, "dcx ") {
+			return fmt.Errorf("recipe %q step is not a dcx command: %s", recipe.Name, step)
+		}
+	}
+	return nil
+}

--- a/recipes/registry_test.go
+++ b/recipes/registry_test.go
@@ -1,0 +1,92 @@
+package recipes
+
+import (
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestLoadEmbeddedRecipes(t *testing.T) {
+	all, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(all) < 3 {
+		t.Fatalf("Load returned %d recipes, want at least 3", len(all))
+	}
+
+	var hasBigQuery, hasSpanner, hasCrossService bool
+	for _, recipe := range all {
+		if len(recipe.Steps) == 0 {
+			t.Fatalf("recipe %s has no steps", recipe.Name)
+		}
+		for _, step := range recipe.Steps {
+			if !strings.HasPrefix(step, "dcx ") {
+				t.Fatalf("recipe %s has non-command step: %s", recipe.Name, step)
+			}
+		}
+		services := strings.Join(recipe.Services, ",")
+		if services == "bigquery" {
+			hasBigQuery = true
+		}
+		if services == "spanner" {
+			hasSpanner = true
+		}
+		if strings.Contains(services, "bigquery") && strings.Contains(services, "ca") && strings.Contains(services, "spanner") {
+			hasCrossService = true
+		}
+	}
+
+	if !hasBigQuery {
+		t.Fatal("missing BigQuery-only recipe")
+	}
+	if !hasSpanner {
+		t.Fatal("missing Spanner-only recipe")
+	}
+	if !hasCrossService {
+		t.Fatal("missing cross-service recipe")
+	}
+}
+
+func TestForDomain(t *testing.T) {
+	all := []Recipe{
+		{Name: "a", Services: []string{"bigquery"}},
+		{Name: "b", Services: []string{"spanner", "ca"}},
+	}
+
+	got := ForDomain(all, "ca")
+	if len(got) != 1 || got[0].Name != "b" {
+		t.Fatalf("ForDomain(ca) = %+v, want recipe b", got)
+	}
+}
+
+func TestLoadFSSupportsStandardTOMLFeatures(t *testing.T) {
+	fsys := fstest.MapFS{
+		"recipes.toml": {
+			Data: []byte(`
+[[recipes]]
+name = "standard-toml" # inline comments should parse
+title = "Standard TOML"
+description = """
+Recipe descriptions may span multiple lines.
+"""
+services = ["bigquery"]
+steps = [
+  "dcx datasets list --format json", # comments inside arrays should parse
+]
+cautions = ["Keep output bounded."]
+`),
+		},
+	}
+
+	all, err := LoadFS(fsys, ".")
+	if err != nil {
+		t.Fatalf("LoadFS: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("LoadFS returned %d recipes, want 1", len(all))
+	}
+	if !strings.Contains(all[0].Description, "span multiple lines") {
+		t.Fatalf("multiline description was not decoded: %q", all[0].Description)
+	}
+}

--- a/recipes/workflows.toml
+++ b/recipes/workflows.toml
@@ -1,0 +1,52 @@
+[[recipes]]
+name = "bigquery-table-inventory"
+title = "Inventory and inspect BigQuery tables"
+description = "List datasets, enumerate tables, inspect a table schema, and run a bounded validation query."
+services = ["bigquery"]
+steps = [
+  "dcx datasets list --project-id $PROJECT_ID --format json",
+  "dcx tables list --project-id $PROJECT_ID --dataset-id $DATASET_ID --page-all --page-limit 10 --format json",
+  "dcx tables get --project-id $PROJECT_ID --dataset-id $DATASET_ID --table-id $TABLE_ID --output-fields tableReference,schema --format json",
+  "dcx jobs query --project-id $PROJECT_ID --location $LOCATION --query \"SELECT COUNT(*) AS row_count FROM $DATASET_ID.$TABLE_ID\" --max-results 1 --format json"
+]
+cautions = [
+  "Keep --page-limit finite unless the caller explicitly needs a full inventory.",
+  "Use --output-fields for schema-only inspection to avoid sending unnecessary table metadata to the agent context."
+]
+
+[[recipes]]
+name = "spanner-schema-migration"
+title = "Apply and verify a Spanner schema migration"
+description = "Capture the current DDL, dry-run a migration file, apply it with an idempotent operation ID, wait for completion, and verify the resulting DDL."
+services = ["spanner"]
+steps = [
+  "dcx spanner databases get-ddl --project-id $PROJECT_ID --instance-id $INSTANCE_ID --database-id $DATABASE_ID --format json",
+  "dcx spanner databases update-ddl --project-id $PROJECT_ID --instance-id $INSTANCE_ID --database-id $DATABASE_ID --ddl-file schema.sql --operation-id migration-001 --dry-run --format json",
+  "dcx spanner databases update-ddl --project-id $PROJECT_ID --instance-id $INSTANCE_ID --database-id $DATABASE_ID --ddl-file schema.sql --operation-id migration-001 --format json",
+  "dcx spanner operations wait --project-id $PROJECT_ID --operation-name $OPERATION_NAME --timeout 120 --poll-interval 5 --format json",
+  "dcx spanner databases get-ddl --project-id $PROJECT_ID --instance-id $INSTANCE_ID --database-id $DATABASE_ID --format json"
+]
+cautions = [
+  "Always set --operation-id for retryable migrations.",
+  "Run the dry-run step before the mutating update-ddl step in unattended workflows."
+]
+
+[[recipes]]
+name = "cross-service-ca-source-onboarding"
+title = "Validate source profiles and bootstrap a CA data agent"
+description = "Validate source profiles, inspect database and BigQuery schemas, then create a Conversational Analytics data agent with a verified query."
+services = ["profiles", "spanner", "alloydb", "cloudsql", "bigquery", "ca"]
+steps = [
+  "dcx profiles validate --format json",
+  "dcx profiles test --format json",
+  "dcx spanner schema describe --profile spanner-finance.yaml --format json",
+  "dcx alloydb schema describe --profile alloydb-ops.yaml --format json",
+  "dcx cloudsql schema describe --profile cloudsql-app.yaml --format json",
+  "dcx tables get --project-id $PROJECT_ID --dataset-id $DATASET_ID --table-id $TABLE_ID --output-fields tableReference,schema --format json",
+  "dcx ca create-agent --project-id $PROJECT_ID --name data-agent --tables $PROJECT_ID.$DATASET_ID.$TABLE_ID --instructions \"Answer using verified source schemas only.\" --format json",
+  "dcx ca add-verified-query --project-id $PROJECT_ID --agent data-agent --question \"How many rows are in the table?\" --query \"SELECT COUNT(*) AS row_count FROM $DATASET_ID.$TABLE_ID\" --format json"
+]
+cautions = [
+  "Run profile validation before creating or updating CA agents.",
+  "Keep verified queries narrow and source-specific so later agent answers stay auditable."
+]


### PR DESCRIPTION
## Summary

Adds TOML-defined workflow recipes and embeds matching recipes into generated domain `SKILL.md` files under a `Workflows` section.

Partial close of #30 (item 5).

### Recipes

- `bigquery-table-inventory` for dataset/table/schema/query inspection
- `spanner-schema-migration` for DDL capture, dry-run, apply, wait, and verify
- `cross-service-ca-source-onboarding` for profile validation, schema inspection, CA agent creation, and verified-query setup

### Design

- `recipes/*.toml` is embedded into the binary via the new `recipes` package
- `meta generate-skills` loads the recipe registry once and filters by domain/service
- Generated skills render a `## Workflows` section before flag reference
- Tests verify embedded recipes load, cover BigQuery/Spanner/cross-service workflows, and every recipe step maps to a registered `dcx` command

## Test plan

- [x] `GOCACHE=/tmp/dcx-go-build go test ./recipes ./internal/cli`
- [x] `GOCACHE=/tmp/dcx-go-build go test ./...`
- [x] `GOCACHE=/tmp/dcx-go-build go vet ./...`

Note: full `go test ./...` needs permission to open local `httptest` ports for `internal/retry` tests; it passes when run outside the filesystem/network sandbox.