### PR TITLE
Add automatic request body schema validation (issue #30 item 6)

### DIFF
--- a/internal/discovery/register.go
+++ b/internal/discovery/register.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/haiyuan-eng-google/dcx-cli/assets"
 	"github.com/haiyuan-eng-google/dcx-cli/internal/auth"
 	"github.com/haiyuan-eng-google/dcx-cli/internal/contracts"
 	dcxerrors "github.com/haiyuan-eng-google/dcx-cli/internal/errors"
@@ -94,6 +95,7 @@ func registerOneCommand(
 	pageDelayMs := 100
 	bodyFlag := ""
 	forceFlag := false
+	noValidate := false
 	isMutation := cmd.Method.IsMutation()
 
 	leafCmd := &cobra.Command{
@@ -133,7 +135,7 @@ func registerOneCommand(
 
 			// For mutations: validate body, check confirmation, handle dry-run.
 			if isMutation {
-				return executeMutationFlow(executor, cmd, *opts, globalFlags, queryParams, bodyFlag, forceFlag, format)
+				return executeMutationFlow(executor, cmd, *opts, globalFlags, queryParams, bodyFlag, forceFlag, noValidate, format)
 			}
 
 			authCfg := auth.Config{
@@ -189,6 +191,7 @@ func registerOneCommand(
 	if isMutation {
 		if cmd.Method.AcceptsBody() {
 			leafCmd.Flags().StringVar(&bodyFlag, "body", "", "JSON request body (or @file.json)")
+			leafCmd.Flags().BoolVar(&noValidate, "no-validate", false, "Skip request body schema validation")
 		}
 		if cmd.Method.RequiresConfirmation() {
 			leafCmd.Flags().BoolVar(&forceFlag, "force", false, "Skip confirmation prompt")
@@ -218,6 +221,7 @@ func registerOneCommand(
 	if isMutation && cmd.Method.AcceptsBody() {
 		contractFlags = append(contractFlags,
 			contracts.FlagContract{Name: "body", Type: "string", Description: "JSON request body (or @file.json)", Required: true},
+			contracts.FlagContract{Name: "no-validate", Type: "bool", Description: "Skip request body schema validation"},
 		)
 	}
 	if isMutation && cmd.Method.RequiresConfirmation() {
@@ -246,6 +250,7 @@ func executeMutationFlow(
 	queryParams map[string]string,
 	bodyFlag string,
 	force bool,
+	noValidate bool,
 	format output.Format,
 ) error {
 	// 1. Load and validate body if the method accepts one.
@@ -260,6 +265,17 @@ func executeMutationFlow(
 		if err != nil {
 			dcxerrors.Emit(dcxerrors.InvalidConfig, err.Error(), "")
 			return nil
+		}
+
+		// Schema validation: check body against Discovery schema.
+		if !noValidate && cmd.Method.RequestRef != "" {
+			docJSON, docErr := assets.DiscoveryDocForDomain(cmd.Service.Domain)
+			if docErr == nil {
+				if validationErrors := ValidateTopLevelProperties(bodyBytes, cmd.Method.RequestRef, docJSON); len(validationErrors) > 0 {
+					dcxerrors.Emit(dcxerrors.InvalidConfig, FormatValidationErrors(validationErrors), "Use --no-validate to skip schema validation")
+					return nil
+				}
+			}
 		}
 	}
 

--- a/internal/discovery/validate_body.go
+++ b/internal/discovery/validate_body.go
@@ -85,7 +85,12 @@ func ValidateTopLevelProperties(body []byte, schemaName string, docJSON []byte) 
 		// Type check for present fields.
 		expectedType, _ := prop["type"].(string)
 		if expectedType == "" {
-			continue // $ref or untyped, skip
+			// $ref properties are expected to be objects.
+			if _, hasRef := prop["$ref"]; hasRef {
+				expectedType = "object"
+			} else {
+				continue // untyped, skip
+			}
 		}
 
 		if err := checkType(propName, value, expectedType); err != nil {

--- a/internal/discovery/validate_body.go
+++ b/internal/discovery/validate_body.go
@@ -1,0 +1,154 @@
+package discovery
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ValidationError describes a single body validation failure.
+type ValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e ValidationError) String() string {
+	if e.Field != "" {
+		return fmt.Sprintf("%s: %s", e.Field, e.Message)
+	}
+	return e.Message
+}
+
+// ValidateTopLevelProperties checks a JSON body against a Discovery schema's
+// top-level properties. Validates:
+//   - Required fields are present (detected via "Required." in description)
+//   - Primitive type matches (string, number/integer, boolean, array, object)
+//
+// Does NOT validate nested $ref objects, array items, enum values, or
+// additionalProperties. Use --no-validate to skip entirely.
+//
+// Returns nil if valid, or a list of validation errors.
+func ValidateTopLevelProperties(body []byte, schemaName string, docJSON []byte) []ValidationError {
+	schemas, err := ExtractSchemas(docJSON)
+	if err != nil {
+		return nil // can't validate, let API handle it
+	}
+
+	schemaRaw, ok := schemas[schemaName]
+	if !ok {
+		return nil // unknown schema, skip
+	}
+
+	schemaMap, ok := schemaRaw.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	properties, ok := schemaMap["properties"].(map[string]interface{})
+	if !ok {
+		return nil // no properties defined
+	}
+
+	// Parse the body.
+	var bodyMap map[string]interface{}
+	if err := json.Unmarshal(body, &bodyMap); err != nil {
+		return []ValidationError{{Message: "body is not a valid JSON object"}}
+	}
+
+	var errors []ValidationError
+
+	// Check required fields and type mismatches.
+	for propName, propRaw := range properties {
+		prop, ok := propRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// Required check: description starts with "Required."
+		desc, _ := prop["description"].(string)
+		isRequired := strings.HasPrefix(strings.TrimSpace(desc), "Required.")
+
+		value, exists := bodyMap[propName]
+
+		if isRequired && !exists {
+			errors = append(errors, ValidationError{
+				Field:   propName,
+				Message: "required field is missing",
+			})
+			continue
+		}
+
+		if !exists {
+			continue
+		}
+
+		// Type check for present fields.
+		expectedType, _ := prop["type"].(string)
+		if expectedType == "" {
+			continue // $ref or untyped, skip
+		}
+
+		if err := checkType(propName, value, expectedType); err != nil {
+			errors = append(errors, *err)
+		}
+	}
+
+	return errors
+}
+
+// FormatValidationErrors produces a single error message from a list of
+// validation errors, suitable for INVALID_CONFIG emission.
+func FormatValidationErrors(errors []ValidationError) string {
+	parts := make([]string, len(errors))
+	for i, e := range errors {
+		parts[i] = e.String()
+	}
+	return "body validation failed: " + strings.Join(parts, "; ")
+}
+
+// checkType validates that a JSON value matches the expected Discovery type.
+// integer and number both map to numeric (JSON float64).
+func checkType(field string, value interface{}, expectedType string) *ValidationError {
+	switch expectedType {
+	case "string":
+		if _, ok := value.(string); !ok {
+			return &ValidationError{Field: field, Message: fmt.Sprintf("expects string, got %s", jsonTypeName(value))}
+		}
+	case "integer", "number":
+		if _, ok := value.(float64); !ok {
+			return &ValidationError{Field: field, Message: fmt.Sprintf("expects %s, got %s", expectedType, jsonTypeName(value))}
+		}
+	case "boolean":
+		if _, ok := value.(bool); !ok {
+			return &ValidationError{Field: field, Message: fmt.Sprintf("expects boolean, got %s", jsonTypeName(value))}
+		}
+	case "array":
+		if _, ok := value.([]interface{}); !ok {
+			return &ValidationError{Field: field, Message: fmt.Sprintf("expects array, got %s", jsonTypeName(value))}
+		}
+	case "object":
+		if _, ok := value.(map[string]interface{}); !ok {
+			return &ValidationError{Field: field, Message: fmt.Sprintf("expects object, got %s", jsonTypeName(value))}
+		}
+	}
+	return nil
+}
+
+func jsonTypeName(v interface{}) string {
+	switch v.(type) {
+	case string:
+		return "string"
+	case float64:
+		return "number"
+	case bool:
+		return "boolean"
+	case []interface{}:
+		return "array"
+	case map[string]interface{}:
+		return "object"
+	case nil:
+		return "null"
+	default:
+		return fmt.Sprintf("%T", v)
+	}
+}

--- a/internal/discovery/validate_body_test.go
+++ b/internal/discovery/validate_body_test.go
@@ -81,6 +81,46 @@ func TestValidateTopLevel_BooleanType(t *testing.T) {
 	}
 }
 
+func TestValidateTopLevel_RefFieldGivenNonObject(t *testing.T) {
+	doc := loadBigQueryDoc(t)
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"null", `{"datasetReference": null}`},
+		{"string", `{"datasetReference": "not-object"}`},
+		{"number", `{"datasetReference": 42}`},
+		{"array", `{"datasetReference": [1,2]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errors := ValidateTopLevelProperties([]byte(tt.body), "Dataset", doc)
+			found := false
+			for _, e := range errors {
+				if e.Field == "datasetReference" && strings.Contains(e.Message, "expects object") {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("expected type error for $ref field given %s, got: %v", tt.name, errors)
+			}
+		})
+	}
+}
+
+func TestValidateTopLevel_RefFieldGivenValidObject(t *testing.T) {
+	doc := loadBigQueryDoc(t)
+	body := []byte(`{"datasetReference": {"datasetId": "test"}}`)
+
+	errors := ValidateTopLevelProperties(body, "Dataset", doc)
+	for _, e := range errors {
+		if e.Field == "datasetReference" {
+			t.Errorf("valid object should not error on $ref field, got: %v", e)
+		}
+	}
+}
+
 func TestValidateTopLevel_UnknownSchema(t *testing.T) {
 	doc := loadBigQueryDoc(t)
 	body := []byte(`{"anything": "goes"}`)

--- a/internal/discovery/validate_body_test.go
+++ b/internal/discovery/validate_body_test.go
@@ -1,0 +1,156 @@
+package discovery
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func loadBigQueryDoc(t *testing.T) []byte {
+	t.Helper()
+	data, err := os.ReadFile("../../assets/bigquery_v2_discovery.json")
+	if err != nil {
+		t.Fatalf("reading discovery doc: %v", err)
+	}
+	return data
+}
+
+func TestValidateTopLevel_MissingRequired(t *testing.T) {
+	doc := loadBigQueryDoc(t)
+	body := []byte(`{"friendlyName": "test"}`)
+
+	errors := ValidateTopLevelProperties(body, "Dataset", doc)
+	if len(errors) == 0 {
+		t.Fatal("expected validation errors for missing required field")
+	}
+
+	found := false
+	for _, e := range errors {
+		if e.Field == "datasetReference" && strings.Contains(e.Message, "required") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error for missing datasetReference, got: %v", errors)
+	}
+}
+
+func TestValidateTopLevel_TypeMismatch(t *testing.T) {
+	doc := loadBigQueryDoc(t)
+	body := []byte(`{"datasetReference": {"datasetId": "test"}, "friendlyName": 123}`)
+
+	errors := ValidateTopLevelProperties(body, "Dataset", doc)
+	if len(errors) == 0 {
+		t.Fatal("expected validation error for type mismatch")
+	}
+
+	found := false
+	for _, e := range errors {
+		if e.Field == "friendlyName" && strings.Contains(e.Message, "expects string") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected type mismatch on friendlyName, got: %v", errors)
+	}
+}
+
+func TestValidateTopLevel_ValidBody(t *testing.T) {
+	doc := loadBigQueryDoc(t)
+	body := []byte(`{"datasetReference": {"datasetId": "test"}, "friendlyName": "My Dataset"}`)
+
+	errors := ValidateTopLevelProperties(body, "Dataset", doc)
+	if len(errors) != 0 {
+		t.Errorf("expected no errors for valid body, got: %v", errors)
+	}
+}
+
+func TestValidateTopLevel_BooleanType(t *testing.T) {
+	doc := loadBigQueryDoc(t)
+	body := []byte(`{"datasetReference": {"datasetId": "test"}, "isCaseInsensitive": "not-a-bool"}`)
+
+	errors := ValidateTopLevelProperties(body, "Dataset", doc)
+	found := false
+	for _, e := range errors {
+		if e.Field == "isCaseInsensitive" && strings.Contains(e.Message, "expects boolean") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected type mismatch on boolean field, got: %v", errors)
+	}
+}
+
+func TestValidateTopLevel_UnknownSchema(t *testing.T) {
+	doc := loadBigQueryDoc(t)
+	body := []byte(`{"anything": "goes"}`)
+
+	errors := ValidateTopLevelProperties(body, "DoesNotExist", doc)
+	if errors != nil {
+		t.Errorf("unknown schema should return nil (skip), got: %v", errors)
+	}
+}
+
+func TestValidateTopLevel_InvalidJSON(t *testing.T) {
+	doc := loadBigQueryDoc(t)
+	body := []byte(`not json`)
+
+	errors := ValidateTopLevelProperties(body, "Dataset", doc)
+	if len(errors) != 1 || !strings.Contains(errors[0].Message, "not a valid JSON object") {
+		t.Errorf("expected JSON parse error, got: %v", errors)
+	}
+}
+
+func TestValidateTopLevel_EmptyBody(t *testing.T) {
+	doc := loadBigQueryDoc(t)
+	body := []byte(`{}`)
+
+	errors := ValidateTopLevelProperties(body, "Dataset", doc)
+	// Should fail for missing required datasetReference.
+	if len(errors) == 0 {
+		t.Fatal("expected error for empty body missing required fields")
+	}
+}
+
+func TestFormatValidationErrors(t *testing.T) {
+	errors := []ValidationError{
+		{Field: "name", Message: "required field is missing"},
+		{Field: "age", Message: "expects number, got string"},
+	}
+	msg := FormatValidationErrors(errors)
+	if !strings.Contains(msg, "body validation failed:") {
+		t.Errorf("missing prefix: %s", msg)
+	}
+	if !strings.Contains(msg, "name: required field is missing") {
+		t.Errorf("missing name error: %s", msg)
+	}
+	if !strings.Contains(msg, "age: expects number, got string") {
+		t.Errorf("missing age error: %s", msg)
+	}
+}
+
+func TestCheckType(t *testing.T) {
+	tests := []struct {
+		value    interface{}
+		expected string
+		wantErr  bool
+	}{
+		{"hello", "string", false},
+		{42.0, "string", true},
+		{42.0, "number", false},
+		{42.0, "integer", false},
+		{"42", "integer", true},
+		{true, "boolean", false},
+		{"true", "boolean", true},
+		{[]interface{}{1}, "array", false},
+		{"[1]", "array", true},
+		{map[string]interface{}{}, "object", false},
+		{"object", "object", true},
+	}
+	for _, tt := range tests {
+		err := checkType("test", tt.value, tt.expected)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("checkType(%v, %q) err=%v, wantErr=%v", tt.value, tt.expected, err, tt.wantErr)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Automatic client-side validation of `--body` JSON against Discovery schemas. Catches errors before the network call. Closes #30 (all 6 items shipped).

### Examples

```bash
# Missing required field → fails before network call
dcx datasets insert --project-id=p --body='{"friendlyName":"test"}' --dry-run
# → INVALID_CONFIG: body validation failed: datasetReference: required field is missing

# Type mismatch → fails before network call
dcx datasets insert --project-id=p --body='{"datasetReference":{"datasetId":"x"},"friendlyName":123}'
# → INVALID_CONFIG: body validation failed: friendlyName: expects string, got number

# Skip validation for forward-compat
dcx datasets insert --project-id=p --body='{"newApiField":"value"}' --no-validate
```

### What's validated (top-level only)

| Check | Example |
|---|---|
| Required fields present | `datasetReference` missing from Dataset body |
| Primitive type matches | `string` field given `123` (number) |

### What's NOT validated (deferred)

- Nested `$ref` objects
- Array item types
- Enum values
- `additionalProperties`

### Design

- Automatic for all mutations with `--body` — no opt-in
- `--no-validate` skips validation (escape hatch for new API fields)
- `--dry-run` validates before rendering
- Single `INVALID_CONFIG` error with all failures joined: `body validation failed: X; Y`
- Wired in `executeMutationFlow` after `LoadBody`, before auth
- Required detection: `strings.HasPrefix(strings.TrimSpace(desc), "Required.")`
- Type handling: `integer` and `number` both map to numeric (JSON float64)

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes (9 new tests)
- [x] Missing required field → `INVALID_CONFIG` before network call
- [x] Type mismatch (string, boolean) → `INVALID_CONFIG`
- [x] Valid body → passes validation, dry-run renders
- [x] `--no-validate` → skips all checks
- [x] Unknown schema → silently skips (let API handle)
- [x] `--no-validate` in contract (`meta describe datasets insert`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)