### PR TITLE
Fix --format text rendering for typed structs (issue #37 item 1)

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -247,7 +247,9 @@ func renderText(value interface{}) error {
 		}
 
 		var normalized interface{}
-		if err := json.Unmarshal(data, &normalized); err != nil {
+		dec := json.NewDecoder(strings.NewReader(string(data)))
+		dec.UseNumber()
+		if err := dec.Decode(&normalized); err != nil {
 			fmt.Fprintln(os.Stdout, Sanitize(string(data)))
 			return nil
 		}
@@ -302,6 +304,8 @@ func formatScalar(v interface{}) string {
 		return ""
 	case string:
 		return val
+	case json.Number:
+		return val.String()
 	case float64:
 		if val == float64(int64(val)) {
 			return fmt.Sprintf("%d", int64(val))

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -232,15 +232,84 @@ func toStringMap(v interface{}) (map[string]interface{}, bool) {
 }
 
 func renderText(value interface{}) error {
-	var s string
 	switch v := value.(type) {
 	case string:
-		s = v
+		fmt.Fprintln(os.Stdout, Sanitize(v))
 	case []byte:
-		s = string(v)
+		fmt.Fprintln(os.Stdout, Sanitize(string(v)))
 	default:
-		s = fmt.Sprintf("%v", v)
+		// Normalize through JSON to use struct tags and produce
+		// readable output instead of raw Go %v representation.
+		data, err := json.Marshal(v)
+		if err != nil {
+			fmt.Fprintln(os.Stdout, Sanitize(fmt.Sprintf("%v", v)))
+			return nil
+		}
+
+		var normalized interface{}
+		if err := json.Unmarshal(data, &normalized); err != nil {
+			fmt.Fprintln(os.Stdout, Sanitize(string(data)))
+			return nil
+		}
+
+		renderTextValue(os.Stdout, normalized, 0)
 	}
-	fmt.Fprintln(os.Stdout, Sanitize(s))
 	return nil
+}
+
+// renderTextValue recursively renders a JSON-normalized value as
+// human-readable text with indentation.
+func renderTextValue(w *os.File, value interface{}, indent int) {
+	prefix := strings.Repeat("  ", indent)
+
+	switch v := value.(type) {
+	case map[string]interface{}:
+		keys := make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			val := v[k]
+			switch val.(type) {
+			case map[string]interface{}, []interface{}:
+				fmt.Fprintf(w, "%s%s:\n", prefix, Sanitize(k))
+				renderTextValue(w, val, indent+1)
+			default:
+				fmt.Fprintf(w, "%s%s: %s\n", prefix, Sanitize(k), Sanitize(formatScalar(val)))
+			}
+		}
+	case []interface{}:
+		for i, item := range v {
+			switch item.(type) {
+			case map[string]interface{}:
+				if i > 0 {
+					fmt.Fprintf(w, "%s---\n", prefix)
+				}
+				renderTextValue(w, item, indent)
+			default:
+				fmt.Fprintf(w, "%s- %s\n", prefix, Sanitize(formatScalar(item)))
+			}
+		}
+	default:
+		fmt.Fprintf(w, "%s%s\n", prefix, Sanitize(formatScalar(v)))
+	}
+}
+
+func formatScalar(v interface{}) string {
+	switch val := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return val
+	case float64:
+		if val == float64(int64(val)) {
+			return fmt.Sprintf("%d", int64(val))
+		}
+		return fmt.Sprintf("%g", val)
+	case bool:
+		return fmt.Sprintf("%t", val)
+	default:
+		return fmt.Sprintf("%v", val)
+	}
 }

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -109,6 +109,83 @@ func TestRenderText(t *testing.T) {
 	}
 }
 
+func TestRenderTextStruct(t *testing.T) {
+	type Result struct {
+		Name   string `json:"name"`
+		Count  int    `json:"count"`
+		Active bool   `json:"active"`
+	}
+
+	out := captureStdout(t, func() {
+		if err := Render(Text, Result{Name: "test", Count: 42, Active: true}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// Should NOT contain raw Go struct syntax.
+	if strings.Contains(out, "&{") || strings.Contains(out, ":{") {
+		t.Errorf("Text output contains raw Go struct: %q", out)
+	}
+	// Should contain key-value pairs from JSON tags.
+	if !strings.Contains(out, "name: test") {
+		t.Errorf("missing 'name: test' in: %q", out)
+	}
+	if !strings.Contains(out, "count: 42") {
+		t.Errorf("missing 'count: 42' in: %q", out)
+	}
+	if !strings.Contains(out, "active: true") {
+		t.Errorf("missing 'active: true' in: %q", out)
+	}
+}
+
+func TestRenderTextStructWithSlice(t *testing.T) {
+	type Item struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	type ListResult struct {
+		Items  []Item `json:"items"`
+		Source string `json:"source"`
+	}
+
+	out := captureStdout(t, func() {
+		if err := Render(Text, ListResult{
+			Items:  []Item{{ID: "a", Name: "Alice"}, {ID: "b", Name: "Bob"}},
+			Source: "test",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if strings.Contains(out, "&{") {
+		t.Errorf("Text output contains raw Go struct: %q", out)
+	}
+	if !strings.Contains(out, "source: test") {
+		t.Errorf("missing 'source: test' in: %q", out)
+	}
+	if !strings.Contains(out, "id: a") {
+		t.Errorf("missing 'id: a' in: %q", out)
+	}
+}
+
+func TestRenderTextMap(t *testing.T) {
+	out := captureStdout(t, func() {
+		if err := Render(Text, map[string]interface{}{
+			"status": "success",
+			"count":  float64(3),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if !strings.Contains(out, "status: success") {
+		t.Errorf("missing 'status: success' in: %q", out)
+	}
+	if !strings.Contains(out, "count: 3") {
+		t.Errorf("missing 'count: 3' in: %q", out)
+	}
+}
+
 func TestRenderTable(t *testing.T) {
 	value := []map[string]interface{}{
 		{"name": "events", "location": "US"},

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -186,6 +186,24 @@ func TestRenderTextMap(t *testing.T) {
 	}
 }
 
+func TestRenderTextLargeInt64(t *testing.T) {
+	// Regression: int64 above 2^53 must not be silently rounded
+	// by float64 conversion during JSON normalization.
+	type Stats struct {
+		BytesProcessed int64 `json:"bytes_processed"`
+	}
+
+	out := captureStdout(t, func() {
+		if err := Render(Text, Stats{BytesProcessed: 9007199254740993}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if !strings.Contains(out, "bytes_processed: 9007199254740993") {
+		t.Errorf("large int64 was corrupted: %q", out)
+	}
+}
+
 func TestRenderTable(t *testing.T) {
 	value := []map[string]interface{}{
 		{"name": "events", "location": "US"},


### PR DESCRIPTION
## Summary

Fixes `--format text` printing raw Go struct syntax (`&{...}`) for typed results like `AskResult` and `AgentsListResult`.

Partial fix for #37 (item 1).

### Before

```
dcx ca list-agents --format text
→ &{[{projects/test-project.../dataAgents/agent_463... The Look Ecommerce 5 ...}] BigQuery}
```

### After

```
dcx ca list-agents --format text
→ items:
    _resource_id: agent_463ea647-...
    display_name: The Look Ecommerce
    example_queries_count: 5
    ---
    _resource_id: agent_f86a22f0-...
    display_name: Agent for BigQuery Agent Analytics Data
  source: BigQuery
```

### How it works

`renderText()` now normalizes structured values (structs, pointers) through a JSON round-trip to get JSON-tagged field names, then renders as sorted key-value text with indentation. Strings and `[]byte` behavior unchanged.

Rendering rules:
- Maps → sorted `key: value` lines
- Slices of maps → separated by `---`
- Nested structures → indented
- Scalars → formatted inline (integers without `.0`, bools, strings)

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes (4 new text rendering tests)
- [x] `ca list-agents --format text` → readable key-value output
- [x] `ca ask --format text` → readable question/SQL/results/explanation
- [x] `auth check --format text` → unchanged (already map)
- [x] JSON, json-minified, table formats → unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)