### PR TITLE
Fix ca ask positional question docs, add CA streaming notes (issue #37 items 2+3)

### DIFF
--- a/internal/cli/ca.go
+++ b/internal/cli/ca.go
@@ -31,9 +31,9 @@ func (a *App) addCACommands() {
 
 	a.Registry.Register(contracts.BuildContract(
 		"ca ask", "ca",
-		"Ask a natural-language question across Data Cloud sources",
+		"Ask a natural-language question across Data Cloud sources. Usage: dcx ca ask \"<question>\" [flags]",
 		[]contracts.FlagContract{
-			{Name: "question", Type: "string", Description: "Natural language question (positional argument)", Required: true},
+			{Name: "question", Type: "string", Description: "Natural language question", Required: true, Positional: true},
 			{Name: "profile", Type: "string", Description: "Source profile name or path"},
 			{Name: "agent", Type: "string", Description: "Data agent name (BigQuery)"},
 			{Name: "tables", Type: "string", Description: "Comma-separated table refs (BigQuery)"},

--- a/internal/cli/generate_skills.go
+++ b/internal/cli/generate_skills.go
@@ -271,6 +271,14 @@ func renderSkill(domain string, cmds []*contracts.CommandContract, domainRecipes
 	}
 	b.WriteString("- Use `dcx meta describe <command>` for the full contract of any command\n")
 
+	// Domain-specific notes.
+	if domain == "ca" {
+		b.WriteString("\n## Notes\n\n")
+		b.WriteString("- `ca ask` takes the question as a **positional argument**, not a flag: `dcx ca ask \"your question\" [flags]`\n")
+		b.WriteString("- Use `--format text` for real-time streaming of thinking steps and SQL (displayed on stderr)\n")
+		b.WriteString("- Use `--format json` for structured output without streaming (complete result on stdout)\n")
+	}
+
 	return b.String()
 }
 
@@ -350,7 +358,7 @@ func nonGlobalFlags(c *contracts.CommandContract) []contracts.FlagContract {
 	}
 	var result []contracts.FlagContract
 	for _, f := range c.Flags {
-		if !globalFlags[f.Name] {
+		if !globalFlags[f.Name] && !f.Positional {
 			result = append(result, f)
 		}
 	}

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -18,6 +18,7 @@ type FlagContract struct {
 	Description string `json:"description"`
 	Required    bool   `json:"required"`
 	Default     string `json:"default,omitempty"`
+	Positional  bool   `json:"positional,omitempty"` // true for positional args (not --flag style)
 }
 
 // CommandContract is the machine-readable specification for a single command.


### PR DESCRIPTION
## Summary

Fixes two dogfooding issues from #37:

### Item 2: `--question` flag removed from `ca ask` contract

The question is a **positional argument** (`dcx ca ask "question"`), not a `--question` flag. The contract previously listed it as a required flag, causing generated skills and `meta describe` to mislead agents.

**Before:** `meta describe ca ask` showed `--question` as required flag
**After:** No `--question` flag; description shows `Usage: dcx ca ask "<question>" [flags]`

### Item 3: CA streaming behavior documented in generated skills

Generated CA skill now includes a Notes section:
```
## Notes
- `ca ask` takes the question as a **positional argument**: `dcx ca ask "your question" [flags]`
- Use `--format text` for real-time streaming of thinking steps and SQL (displayed on stderr)
- Use `--format json` for structured output without streaming (complete result on stdout)
```

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes
- [x] `meta describe ca ask` no longer shows `--question`
- [x] `meta generate-skills --domains ca` shows Notes section with positional + streaming guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)