### PR TITLE
Add ca delete-agent for agent lifecycle management (issue #37 item 4)

### DIFF
--- a/internal/ca/client.go
+++ b/internal/ca/client.go
@@ -598,6 +598,37 @@ func (c *Client) AddVerifiedQuery(ctx context.Context, token, projectID, _ strin
 	}, nil
 }
 
+// DeleteAgent deletes a data agent. Agent management always uses locations/global.
+func (c *Client) DeleteAgent(ctx context.Context, token, projectID, agentID string) (*DeleteAgentResult, error) {
+	if projectID == "" {
+		return nil, fmt.Errorf("project ID is required")
+	}
+
+	agentResourceName := fmt.Sprintf("projects/%s/locations/global/dataAgents/%s", projectID, agentID)
+	deleteURL := fmt.Sprintf(dataAgentURLFmt, agentResourceName)
+
+	req, err := http.NewRequestWithContext(ctx, "DELETE", deleteURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("delete-agent API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, readAPIError(resp)
+	}
+
+	return &DeleteAgentResult{
+		AgentID: agentID,
+		Status:  "deleted",
+	}, nil
+}
+
 // parseAgentSummary extracts a summary from a raw DataAgent JSON map.
 func parseAgentSummary(m map[string]interface{}) AgentSummary {
 	agent := AgentSummary{}

--- a/internal/ca/models.go
+++ b/internal/ca/models.go
@@ -106,6 +106,12 @@ type AddVerifiedQueryResult struct {
 	Status               string `json:"status"`
 }
 
+// DeleteAgentResult is the output of ca delete-agent.
+type DeleteAgentResult struct {
+	AgentID string `json:"agent_id"`
+	Status  string `json:"status"`
+}
+
 // AskResult is the unified output for ca ask across all source types.
 type AskResult struct {
 	Question    string      `json:"question"`

--- a/internal/cli/ca.go
+++ b/internal/cli/ca.go
@@ -27,6 +27,7 @@ func (a *App) addCACommands() {
 	caCmd.AddCommand(a.caCreateAgentCmd())
 	caCmd.AddCommand(a.caListAgentsCmd())
 	caCmd.AddCommand(a.caAddVerifiedQueryCmd())
+	caCmd.AddCommand(a.caDeleteAgentCmd())
 	a.Root.AddCommand(caCmd)
 
 	a.Registry.Register(contracts.BuildContract(
@@ -64,6 +65,15 @@ func (a *App) addCACommands() {
 			{Name: "agent", Type: "string", Description: "Data agent name", Required: true},
 			{Name: "question", Type: "string", Description: "Natural language question", Required: true},
 			{Name: "query", Type: "string", Description: "SQL query", Required: true},
+		},
+		true, false,
+	))
+	a.Registry.Register(contracts.BuildContract(
+		"ca delete-agent", "ca",
+		"Delete a data agent",
+		[]contracts.FlagContract{
+			{Name: "name", Type: "string", Description: "Agent ID to delete", Required: true},
+			{Name: "force", Type: "bool", Description: "Skip confirmation prompt"},
 		},
 		true, false,
 	))
@@ -344,6 +354,88 @@ func (a *App) caAddVerifiedQueryCmd() *cobra.Command {
 	cmd.Flags().StringVar(&query, "query", "", "SQL query (required)")
 
 	return cmd
+}
+
+func (a *App) caDeleteAgentCmd() *cobra.Command {
+	var name string
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "delete-agent",
+		Short: "Delete a data agent",
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			if name == "" {
+				dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --name is missing", "")
+				return nil
+			}
+
+			format, err := a.OutputFormat()
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.InvalidConfig, err.Error(), "")
+				return nil
+			}
+
+			// Confirmation for destructive operation.
+			if !force {
+				if err := confirmDelete("ca delete-agent", name); err != nil {
+					dcxerrors.Emit(dcxerrors.MissingArgument, err.Error(), "Use --force to skip confirmation")
+					return nil
+				}
+			}
+
+			ctx := context.Background()
+			resolved, err := auth.Resolve(ctx, a.AuthConfig())
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.AuthError, err.Error(), "")
+				return nil
+			}
+			tok, err := resolved.TokenSource.Token()
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.AuthError, fmt.Sprintf("failed to obtain token: %v", err), "")
+				return nil
+			}
+
+			projectID := a.Opts.ProjectID
+			if projectID == "" {
+				dcxerrors.Emit(dcxerrors.MissingArgument, "required flag --project-id is missing", "")
+				return nil
+			}
+
+			client := ca.NewClient(nil, a.Opts.Retry)
+			result, err := client.DeleteAgent(ctx, tok.AccessToken, projectID, name)
+			if err != nil {
+				dcxerrors.EmitAPIError(err)
+				return nil
+			}
+
+			return a.Render(format, result)
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Agent ID to delete (required)")
+	cmd.Flags().BoolVar(&force, "force", false, "Skip confirmation prompt")
+
+	return cmd
+}
+
+// confirmDelete checks for TTY confirmation on destructive operations.
+func confirmDelete(command, resourceID string) error {
+	if !isTerminal() {
+		return fmt.Errorf("DELETE requires --force when stdin is not a terminal")
+	}
+	fmt.Fprintf(os.Stderr, "This will delete %s %s. Continue? [y/N] ", command, resourceID)
+	var response string
+	fmt.Scanln(&response)
+	response = strings.TrimSpace(strings.ToLower(response))
+	if response != "y" && response != "yes" {
+		return fmt.Errorf("aborted by user")
+	}
+	return nil
+}
+
+func isTerminal() bool {
+	fi, _ := os.Stdin.Stat()
+	return fi.Mode()&os.ModeCharDevice != 0
 }
 
 func splitCSV(s string) []string {

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -133,6 +133,7 @@ func TestCommandDiscovery(t *testing.T) {
 		// CA
 		"dcx ca ask",
 		"dcx ca create-agent", "dcx ca list-agents", "dcx ca add-verified-query",
+		"dcx ca delete-agent",
 		// Auth
 		"dcx auth check", "dcx auth status",
 		// Profiles
@@ -157,8 +158,8 @@ func TestCommandDiscovery(t *testing.T) {
 		}
 	}
 
-	if len(commands) < 85 {
-		t.Errorf("expected at least 85 commands, got %d", len(commands))
+	if len(commands) < 86 {
+		t.Errorf("expected at least 86 commands, got %d", len(commands))
 	}
 }
 


### PR DESCRIPTION
## Summary

New command: `dcx ca delete-agent` (85 → 86 commands). Completes the CA agent lifecycle: create → list → ask → add-verified-query → **delete**.

Closes #37 (all 4 items).

### Usage

```bash
# Delete with confirmation prompt (interactive)
dcx ca delete-agent --project-id=myproject --name=my-agent

# Delete without prompt (non-interactive/CI)
dcx ca delete-agent --project-id=myproject --name=my-agent --force
```

### Safety

- Non-TTY stdin without `--force` → fails closed with structured error
- `is_mutation: true` in contract → excluded from MCP tools/list
- Uses `locations/global` (same as create/list)

### E2E verified

```
create-agent → list-agents (exists) → delete-agent --force → list-agents (gone)
```

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes
- [x] Create → delete → verify gone lifecycle works
- [x] `--force` bypasses confirmation
- [x] Contract: `is_mutation=true`, flags `name` + `force`
- [x] Eval suite updated (86 commands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)