### PR TITLE
Fix empty list responses returning phantom item instead of []

### DIFF
--- a/internal/discovery/executor.go
+++ b/internal/discovery/executor.go
@@ -265,8 +265,9 @@ func extractItems(raw map[string]interface{}) []interface{} {
 		}
 	}
 
-	// Nothing found — return the raw response as a single item.
-	return []interface{}{raw}
+	// Nothing found — return empty. This happens when the API returns
+	// an empty list (e.g., {} with no items key for models/routines).
+	return []interface{}{}
 }
 
 func sourceName(domain string) string {

--- a/internal/discovery/flatpath_test.go
+++ b/internal/discovery/flatpath_test.go
@@ -346,9 +346,9 @@ func TestExtractItemsDynamic(t *testing.T) {
 			want: 1,
 		},
 		{
-			name: "no array returns raw as single item",
+			name: "no array returns empty for list responses",
 			raw:  map[string]interface{}{"name": "projects/x/databases/y"},
-			want: 1,
+			want: 0,
 		},
 	}
 


### PR DESCRIPTION
## Summary

Empty API list responses (like `models list` returning `{}`) produced `{"items":[{}]}` instead of `{"items":[]}`. Agents checking `len(items)` saw 1 phantom item with empty `_resource_id`.

Found during Batch 1 dogfooding (#41).

### Before
```json
{"items":[{}],"source":"BigQuery"}  // 1 empty phantom item
```

### After
```json
{"items":[],"source":"BigQuery"}  // correctly empty
```

### Root cause

`extractItems` fallback returned `[]interface{}{raw}` when no known item array key was found. Changed to `[]interface{}{}`.

## Test plan

- [x] `go test ./... -count=1` passes
- [x] Test updated: "no array returns empty for list responses" (was "returns raw as single item")

🤖 Generated with [Claude Code](https://claude.com/claude-code)