### PR TITLE
Add interactive dcx repl for iterative Data Cloud sessions (issue #45)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/olekukonko/ll v0.1.6 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
+	github.com/peterh/liner v1.2.2 // indirect
 	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,7 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
 github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
@@ -30,6 +31,8 @@ github.com/olekukonko/tablewriter v1.1.4 h1:ORUMI3dXbMnRlRggJX3+q7OzQFDdvgbN9nVW
 github.com/olekukonko/tablewriter v1.1.4/go.mod h1:+kedxuyTtgoZLwif3P1Em4hARJs+mVnzKxmsCL/C5RY=
 github.com/pelletier/go-toml/v2 v2.3.0 h1:k59bC/lIZREW0/iVaQR8nDHxVq8OVlIzYCOJf421CaM=
 github.com/pelletier/go-toml/v2 v2.3.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/peterh/liner v1.2.2 h1:aJ4AOodmL+JxOZZEL2u9iJf8omNRpqHc/EbrK+3mAXw=
+github.com/peterh/liner v1.2.2/go.mod h1:xFwJyiKIXJZUKItq5dGHZSTBRAuG/CpeNpWLyiNRNwI=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
@@ -39,6 +42,7 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
+golang.org/x/sys v0.0.0-20211117180635-dee7805ff2e1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/internal/cli/repl.go
+++ b/internal/cli/repl.go
@@ -59,7 +59,9 @@ Examples:
   dcx> ca ask "top errors yesterday"
   dcx> exit`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runREPL(a)
+			formatExplicit := cmd.Flags().Changed("format") ||
+				cmd.InheritedFlags().Changed("format")
+			return runREPL(a, formatExplicit)
 		},
 	}
 
@@ -68,7 +70,7 @@ Examples:
 	// repl is interactive/human-only, not agent-discoverable.
 }
 
-func runREPL(app *App) error {
+func runREPL(app *App, formatExplicit bool) error {
 	dcxBinary, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("resolving executable path: %w", err)
@@ -82,7 +84,7 @@ func runREPL(app *App) error {
 		CredentialsFile: app.Opts.CredentialsFile,
 		Retry:           app.Opts.Retry,
 		OutputFields:    app.Opts.OutputFields,
-		Format:          "text", // human-readable default for REPL
+		Format:          replDefaultFormat(app.Opts.Format, formatExplicit),
 	}
 
 	line := liner.NewLiner()
@@ -464,6 +466,15 @@ func flagsPresent(args []string) map[string]bool {
 		}
 	}
 	return present
+}
+
+// replDefaultFormat returns the session format: use explicit --format if set,
+// otherwise default to "text" for human-readable REPL output.
+func replDefaultFormat(optsFormat string, explicit bool) string {
+	if explicit {
+		return optsFormat
+	}
+	return "text"
 }
 
 func appendFormatIfMissing(args []string, format string) []string {

--- a/internal/cli/repl.go
+++ b/internal/cli/repl.go
@@ -14,12 +14,16 @@ import (
 
 // replContext holds session state across REPL commands.
 type replContext struct {
-	ProjectID string
-	DatasetID string
-	Location  string
-	Profile   string
-	Agent     string
-	Format    string // session output format (default: text)
+	ProjectID       string
+	DatasetID       string
+	Location        string
+	Profile         string
+	Agent           string
+	Format          string // session output format (default: text)
+	Token           string // forwarded from parent --token
+	CredentialsFile string // forwarded from parent --credentials-file
+	Retry           int    // forwarded from parent --retry
+	OutputFields    string // forwarded from parent --output-fields
 }
 
 // blockedCommands are interactive/server commands that shouldn't run in the REPL.
@@ -71,10 +75,14 @@ func runREPL(app *App) error {
 	}
 
 	ctx := replContext{
-		ProjectID: app.Opts.ProjectID,
-		DatasetID: app.Opts.DatasetID,
-		Location:  app.Opts.Location,
-		Format:    "text", // human-readable default for REPL
+		ProjectID:       app.Opts.ProjectID,
+		DatasetID:       app.Opts.DatasetID,
+		Location:        app.Opts.Location,
+		Token:           app.Opts.Token,
+		CredentialsFile: app.Opts.CredentialsFile,
+		Retry:           app.Opts.Retry,
+		OutputFields:    app.Opts.OutputFields,
+		Format:          "text", // human-readable default for REPL
 	}
 
 	line := liner.NewLiner()
@@ -406,6 +414,9 @@ func injectContext(args []string, ctx replContext, app *App) []string {
 		result = append(result, "--agent", ctx.Agent)
 	}
 
+	// Always forward auth/config globals (these are accepted by all commands).
+	result = appendAuthAndConfigFlags(result, ctx, present)
+
 	return result
 }
 
@@ -419,6 +430,24 @@ func injectGlobalContext(args []string, ctx replContext) []string {
 	}
 	if ctx.Location != "" && !present["location"] {
 		args = append(args, "--location", ctx.Location)
+	}
+	args = appendAuthAndConfigFlags(args, ctx, present)
+	return args
+}
+
+// appendAuthAndConfigFlags forwards auth/config globals to subprocess commands.
+func appendAuthAndConfigFlags(args []string, ctx replContext, present map[string]bool) []string {
+	if ctx.Token != "" && !present["token"] {
+		args = append(args, "--token", ctx.Token)
+	}
+	if ctx.CredentialsFile != "" && !present["credentials-file"] {
+		args = append(args, "--credentials-file", ctx.CredentialsFile)
+	}
+	if ctx.Retry > 0 && !present["retry"] {
+		args = append(args, "--retry", fmt.Sprintf("%d", ctx.Retry))
+	}
+	if ctx.OutputFields != "" && !present["output-fields"] {
+		args = append(args, "--output-fields", ctx.OutputFields)
 	}
 	return args
 }

--- a/internal/cli/repl.go
+++ b/internal/cli/repl.go
@@ -1,0 +1,445 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/haiyuan-eng-google/dcx-cli/internal/contracts"
+	"github.com/peterh/liner"
+	"github.com/spf13/cobra"
+)
+
+// replContext holds session state across REPL commands.
+type replContext struct {
+	ProjectID string
+	DatasetID string
+	Location  string
+	Profile   string
+	Agent     string
+	Format    string // session output format (default: text)
+}
+
+// blockedCommands are interactive/server commands that shouldn't run in the REPL.
+var blockedCommands = map[string]bool{
+	"repl":       true,
+	"mcp":        true,
+	"completion": true,
+}
+
+func (a *App) addREPLCommand() {
+	cmd := &cobra.Command{
+		Use:   "repl",
+		Short: "Start an interactive Data Cloud session",
+		Long: `Start an interactive REPL for iterative Data Cloud work.
+
+Any dcx command can be run by typing it without the "dcx" prefix.
+Bare SELECT/WITH SQL is auto-routed to jobs query.
+
+Context commands:
+  set project P       Set default --project-id
+  set dataset D       Set default --dataset-id
+  set location L      Set default --location
+  set profile P       Set default --profile
+  set agent A         Set default --agent
+  show context        Show current session context
+  clear context       Reset all context
+  /format text        Change session output format
+
+Examples:
+  dcx> datasets list
+  dcx> set dataset analytics
+  dcx> SELECT COUNT(*) FROM events
+  dcx> ca ask "top errors yesterday"
+  dcx> exit`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runREPL(a)
+		},
+	}
+
+	a.Root.AddCommand(cmd)
+	// Intentionally NOT registered in contract registry.
+	// repl is interactive/human-only, not agent-discoverable.
+}
+
+func runREPL(app *App) error {
+	dcxBinary, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolving executable path: %w", err)
+	}
+
+	ctx := replContext{
+		ProjectID: app.Opts.ProjectID,
+		DatasetID: app.Opts.DatasetID,
+		Location:  app.Opts.Location,
+		Format:    "text", // human-readable default for REPL
+	}
+
+	line := liner.NewLiner()
+	defer line.Close()
+	line.SetCtrlCAborts(true)
+
+	fmt.Fprintf(os.Stderr, "dcx interactive session. Type 'help' for commands, 'exit' to quit.\n")
+	if ctx.ProjectID != "" {
+		fmt.Fprintf(os.Stderr, "  project: %s\n", ctx.ProjectID)
+	}
+
+	for {
+		prompt := "dcx> "
+		input, err := line.Prompt(prompt)
+		if err != nil {
+			// Ctrl-D or error
+			fmt.Fprintln(os.Stderr)
+			return nil
+		}
+
+		input = strings.TrimSpace(input)
+		if input == "" {
+			continue
+		}
+
+		line.AppendHistory(input)
+
+		// Handle builtins.
+		if handleBuiltin(input, &ctx) {
+			continue
+		}
+
+		// Handle exit.
+		if input == "exit" || input == "quit" {
+			return nil
+		}
+
+		// Handle bare SQL.
+		var args []string
+		if isBareReadOnlySQL(input) {
+			sql := collectMultilineSQL(input, line)
+			args = []string{"jobs", "query", "--query", sql}
+		} else if strings.HasPrefix(strings.ToLower(input), "dry-run ") && isBareReadOnlySQL(input[8:]) {
+			sql := collectMultilineSQL(input[8:], line)
+			args = []string{"jobs", "query", "--query", sql, "--dry-run"}
+		} else {
+			args = parseLineToArgv(input)
+		}
+
+		// Strip "dcx" prefix if user types it.
+		if len(args) > 0 && args[0] == "dcx" {
+			args = args[1:]
+		}
+
+		if len(args) == 0 {
+			continue
+		}
+
+		// Block interactive/server commands.
+		if isBlockedCommand(args) {
+			fmt.Fprintf(os.Stderr, "  command not available in REPL: %s\n", args[0])
+			continue
+		}
+
+		// Inject session context (contract-aware).
+		args = injectContext(args, ctx, app)
+
+		// Append format if not already specified.
+		args = appendFormatIfMissing(args, ctx.Format)
+
+		// Execute as subprocess.
+		execCmd := exec.CommandContext(context.Background(), dcxBinary, args...)
+		execCmd.Stdout = os.Stdout
+		execCmd.Stderr = os.Stderr
+		execCmd.Stdin = os.Stdin
+		execCmd.Run() // ignore exit code — errors printed via stderr
+		fmt.Println() // blank line after output for readability
+	}
+}
+
+func handleBuiltin(input string, ctx *replContext) bool {
+	lower := strings.ToLower(input)
+
+	if lower == "help" || lower == "?" {
+		printREPLHelp()
+		return true
+	}
+
+	if lower == "show context" {
+		printContext(ctx)
+		return true
+	}
+
+	if lower == "clear context" {
+		*ctx = replContext{Format: ctx.Format}
+		fmt.Fprintln(os.Stderr, "  context cleared")
+		return true
+	}
+
+	if strings.HasPrefix(lower, "set ") {
+		handleSet(input[4:], ctx)
+		return true
+	}
+
+	if strings.HasPrefix(lower, "/format ") {
+		ctx.Format = strings.TrimSpace(input[8:])
+		fmt.Fprintf(os.Stderr, "  format: %s\n", ctx.Format)
+		return true
+	}
+
+	return false
+}
+
+func handleSet(rest string, ctx *replContext) {
+	parts := strings.SplitN(strings.TrimSpace(rest), " ", 2)
+	if len(parts) != 2 {
+		fmt.Fprintln(os.Stderr, "  usage: set <key> <value>")
+		fmt.Fprintln(os.Stderr, "  keys: project, dataset, location, profile, agent")
+		return
+	}
+
+	key := strings.ToLower(parts[0])
+	value := strings.TrimSpace(parts[1])
+
+	switch key {
+	case "project":
+		ctx.ProjectID = value
+	case "dataset":
+		ctx.DatasetID = value
+	case "location":
+		ctx.Location = value
+	case "profile":
+		ctx.Profile = value
+	case "agent":
+		ctx.Agent = value
+	default:
+		fmt.Fprintf(os.Stderr, "  unknown context key: %s\n", key)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "  %s: %s\n", key, value)
+}
+
+func printContext(ctx *replContext) {
+	fmt.Fprintln(os.Stderr, "  session context:")
+	if ctx.ProjectID != "" {
+		fmt.Fprintf(os.Stderr, "    project:  %s\n", ctx.ProjectID)
+	}
+	if ctx.DatasetID != "" {
+		fmt.Fprintf(os.Stderr, "    dataset:  %s\n", ctx.DatasetID)
+	}
+	if ctx.Location != "" {
+		fmt.Fprintf(os.Stderr, "    location: %s\n", ctx.Location)
+	}
+	if ctx.Profile != "" {
+		fmt.Fprintf(os.Stderr, "    profile:  %s\n", ctx.Profile)
+	}
+	if ctx.Agent != "" {
+		fmt.Fprintf(os.Stderr, "    agent:    %s\n", ctx.Agent)
+	}
+	fmt.Fprintf(os.Stderr, "    format:   %s\n", ctx.Format)
+	if ctx.ProjectID == "" && ctx.DatasetID == "" && ctx.Location == "" && ctx.Profile == "" && ctx.Agent == "" {
+		fmt.Fprintln(os.Stderr, "    (no context set)")
+	}
+}
+
+func printREPLHelp() {
+	fmt.Fprintln(os.Stderr, `  dcx interactive session
+
+  Commands:
+    <any dcx command>           Run without "dcx" prefix
+    SELECT ... / WITH ...       Bare SQL routed to jobs query
+    dry-run SELECT ...          SQL dry-run
+
+  Context:
+    set project <P>             Set default --project-id
+    set dataset <D>             Set default --dataset-id
+    set location <L>            Set default --location
+    set profile <P>             Set default --profile
+    set agent <A>               Set default --agent
+    show context                Show current context
+    clear context               Reset all context
+
+  Session:
+    /format <fmt>               Change output format (text, json, table, json-minified)
+    help / ?                    Show this help
+    exit / quit / Ctrl-D        Exit`)
+}
+
+// isBareReadOnlySQL detects SELECT/WITH SQL statements.
+func isBareReadOnlySQL(input string) bool {
+	upper := strings.ToUpper(strings.TrimSpace(input))
+	return strings.HasPrefix(upper, "SELECT ") ||
+		strings.HasPrefix(upper, "SELECT\n") ||
+		strings.HasPrefix(upper, "WITH ") ||
+		strings.HasPrefix(upper, "WITH\n") ||
+		upper == "SELECT" ||
+		upper == "WITH"
+}
+
+// collectMultilineSQL continues reading if the SQL doesn't end with ;
+func collectMultilineSQL(initial string, line *liner.State) string {
+	sql := initial
+	for !strings.HasSuffix(strings.TrimSpace(sql), ";") {
+		more, err := line.Prompt("  ...> ")
+		if err != nil {
+			break
+		}
+		line.AppendHistory(more)
+		sql += "\n" + more
+	}
+	// Strip trailing semicolon.
+	sql = strings.TrimSpace(sql)
+	if strings.HasSuffix(sql, ";") {
+		sql = sql[:len(sql)-1]
+	}
+	return strings.TrimSpace(sql)
+}
+
+// parseLineToArgv splits input into arguments, respecting quotes.
+func parseLineToArgv(input string) []string {
+	var args []string
+	var current strings.Builder
+	inQuote := false
+	quoteChar := byte(0)
+
+	for i := 0; i < len(input); i++ {
+		ch := input[i]
+		if inQuote {
+			if ch == quoteChar {
+				inQuote = false
+			} else {
+				current.WriteByte(ch)
+			}
+		} else if ch == '"' || ch == '\'' {
+			inQuote = true
+			quoteChar = ch
+		} else if ch == ' ' || ch == '\t' {
+			if current.Len() > 0 {
+				args = append(args, current.String())
+				current.Reset()
+			}
+		} else {
+			current.WriteByte(ch)
+		}
+	}
+	if current.Len() > 0 {
+		args = append(args, current.String())
+	}
+	return args
+}
+
+func isBlockedCommand(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	if blockedCommands[args[0]] {
+		return true
+	}
+	// Block "spanner operations wait" and similar wait commands.
+	if len(args) >= 2 && args[len(args)-1] == "wait" {
+		return true
+	}
+	// More precise: check last subcommand segment.
+	for i := len(args) - 1; i >= 0; i-- {
+		if args[i] == "wait" && !strings.HasPrefix(args[i], "--") {
+			return true
+		}
+		if strings.HasPrefix(args[i], "--") {
+			continue
+		}
+		break
+	}
+	return false
+}
+
+// injectContext adds session context flags to the command, but only if
+// the command's contract accepts them.
+func injectContext(args []string, ctx replContext, app *App) []string {
+	// Build the command path to look up the contract.
+	// Try progressively shorter prefixes to find the matching contract
+	// (handles positional args that aren't part of the command path).
+	var cmdParts []string
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			break
+		}
+		cmdParts = append(cmdParts, a)
+	}
+
+	var contract *contracts.CommandContract
+	var ok bool
+	for i := len(cmdParts); i >= 1; i-- {
+		commandPath := "dcx " + strings.Join(cmdParts[:i], " ")
+		contract, ok = app.Registry.Get(commandPath)
+		if ok {
+			break
+		}
+	}
+	if !ok {
+		// Unknown command — inject global flags anyway, let cobra handle errors.
+		return injectGlobalContext(args, ctx)
+	}
+
+	// Build flag set from contract.
+	acceptedFlags := make(map[string]bool)
+	for _, f := range contract.Flags {
+		acceptedFlags[f.Name] = true
+	}
+
+	result := make([]string, len(args))
+	copy(result, args)
+
+	// Only inject if the flag is accepted AND not already present.
+	present := flagsPresent(args)
+
+	if ctx.ProjectID != "" && acceptedFlags["project-id"] && !present["project-id"] {
+		result = append(result, "--project-id", ctx.ProjectID)
+	}
+	if ctx.DatasetID != "" && acceptedFlags["dataset-id"] && !present["dataset-id"] {
+		result = append(result, "--dataset-id", ctx.DatasetID)
+	}
+	if ctx.Location != "" && acceptedFlags["location"] && !present["location"] {
+		result = append(result, "--location", ctx.Location)
+	}
+	if ctx.Profile != "" && acceptedFlags["profile"] && !present["profile"] {
+		result = append(result, "--profile", ctx.Profile)
+	}
+	if ctx.Agent != "" && acceptedFlags["agent"] && !present["agent"] {
+		result = append(result, "--agent", ctx.Agent)
+	}
+
+	return result
+}
+
+func injectGlobalContext(args []string, ctx replContext) []string {
+	present := flagsPresent(args)
+	if ctx.ProjectID != "" && !present["project-id"] {
+		args = append(args, "--project-id", ctx.ProjectID)
+	}
+	if ctx.DatasetID != "" && !present["dataset-id"] {
+		args = append(args, "--dataset-id", ctx.DatasetID)
+	}
+	if ctx.Location != "" && !present["location"] {
+		args = append(args, "--location", ctx.Location)
+	}
+	return args
+}
+
+func flagsPresent(args []string) map[string]bool {
+	present := make(map[string]bool)
+	for _, a := range args {
+		if strings.HasPrefix(a, "--") {
+			name := strings.TrimPrefix(a, "--")
+			if before, _, ok := strings.Cut(name, "="); ok {
+				name = before
+			}
+			present[name] = true
+		}
+	}
+	return present
+}
+
+func appendFormatIfMissing(args []string, format string) []string {
+	if flagsPresent(args)["format"] {
+		return args
+	}
+	return append(args, "--format", format)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -108,6 +108,9 @@ Structured output, typed errors, and an MCP bridge for AI agents.`,
 	// Register shell completion command.
 	app.addCompletionCommand()
 
+	// Register interactive REPL (not in contract registry — human-only).
+	app.addREPLCommand()
+
 	return app
 }
 


### PR DESCRIPTION
## Summary

New command: `dcx repl` — interactive REPL for the full 86-command Data Cloud surface. Any dcx command runs by typing it without the `dcx` prefix. Bare SQL auto-routes to `jobs query`.

Implements #45.

### Demo

```text
$ dcx repl --project-id=my-project
dcx> set dataset analytics
dcx> tables list --output-fields=_resource_id
  [table list renders]
dcx> SELECT COUNT(*) FROM events WHERE event_date = CURRENT_DATE();
  row_count: 42381
dcx> set agent support-bot
dcx> ca ask "top errors yesterday"
  [CA streaming + answer]
dcx> spanner instance-configs list --output-fields=_resource_id
  [configs render]
dcx> exit
```

### Features

| Feature | Description |
|---|---|
| Any dcx command | Type without `dcx` prefix |
| Bare SQL | `SELECT`/`WITH` auto-routed to `jobs query` |
| Multi-line SQL | Lines without `;` continue |
| `dry-run` SQL | `dry-run SELECT ...` |
| Session context | `set project/dataset/location/profile/agent` |
| Contract-aware injection | Only injects flags the command accepts |
| `/format` toggle | Switch between text/json/table/json-minified |
| Command history | Up-arrow (via liner library) |
| Blocked commands | `repl`, `mcp serve`, `completion`, `wait` excluded |
| Not in contracts | Human-only — `meta commands` stays at 86 |

### Design

- **Subprocess execution:** Each command runs as a child process via `os.Executable()`. Avoids `os.Exit` in error handlers and Cobra state leaking.
- **Contract-aware context:** `set agent X` only injects `--agent` into commands whose contract has that flag (e.g., `ca ask` but not `datasets list`).
- **Mutation safety preserved:** `--force`/confirmation prompts work normally in the subprocess.

### Verified

- `datasets list` with session context
- Bare SQL (`SELECT 1 as x, 2 as y;`)
- CA ask with agent context (streaming works)
- Blocked commands show error and return to prompt
- `meta commands` stays at 86 (repl not registered)

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes
- [x] Context: `set project` → `show context` → commands use it
- [x] Bare SQL: auto-routed to `jobs query`
- [x] CA ask: `set agent` + `ca ask "question"` works with streaming
- [x] Blocked: `mcp serve` shows error, returns to prompt
- [x] Contract count: `meta commands` = 86 (repl excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)