### PR TITLE
Fix REPL clear context to preserve auth/config globals

### DIFF
--- a/internal/cli/repl.go
+++ b/internal/cli/repl.go
@@ -179,7 +179,14 @@ func handleBuiltin(input string, ctx *replContext) bool {
 	}
 
 	if lower == "clear context" {
-		*ctx = replContext{Format: ctx.Format}
+		// Clear resource context only. Preserve auth/config forwarding
+		// and session settings so --token/--credentials-file sessions
+		// aren't broken by clearing context.
+		ctx.ProjectID = ""
+		ctx.DatasetID = ""
+		ctx.Location = ""
+		ctx.Profile = ""
+		ctx.Agent = ""
 		fmt.Fprintln(os.Stderr, "  context cleared")
 		return true
 	}


### PR DESCRIPTION
## Summary

`clear context` in the REPL reset the entire `replContext` struct, dropping `--token`, `--credentials-file`, `--retry`, and `--output-fields`. Sessions started with explicit auth broke after clearing context.

### Before

```
$ dcx repl --token=my-token
dcx> set project P
dcx> clear context
dcx> set project P
dcx> datasets list
→ Falls through to ADC (token lost)
```

### After

```
dcx> clear context
→ Clears: project, dataset, location, profile, agent
→ Preserves: token, credentials-file, retry, output-fields, format
```

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes
- [x] `--token=fake` forwarded after `clear context` (AUTH_ERROR = token reached API)
- [x] `--format json-minified` preserved after `clear context`

🤖 Generated with [Claude Code](https://claude.com/claude-code)