### PR TITLE
REPL P1: subprocess capture + $last result references (issue #47)

### DIFF
--- a/internal/cli/repl.go
+++ b/internal/cli/repl.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/haiyuan-eng-google/dcx-cli/internal/contracts"
@@ -540,11 +541,14 @@ func executeAndCapture(binary string, args []string) commandResult {
 
 	stdout := stdoutBuf.String()
 
-	// Try to parse stdout as JSON for $last.
+	// Try to parse stdout as JSON for $last. Use json.Number to
+	// preserve large int64 values without float64 precision loss.
 	var parsed interface{}
 	trimmed := strings.TrimSpace(stdout)
 	if len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') {
-		if json.Unmarshal([]byte(trimmed), &parsed) != nil {
+		dec := json.NewDecoder(strings.NewReader(trimmed))
+		dec.UseNumber()
+		if dec.Decode(&parsed) != nil {
 			parsed = nil
 		}
 	}
@@ -622,8 +626,8 @@ func resolveLastRef(arg string, jsonData interface{}) (string, error) {
 			if !ok {
 				return "", fmt.Errorf("$last: cannot index non-array")
 			}
-			var index int
-			if _, err := fmt.Sscanf(indexStr, "%d", &index); err != nil {
+			index, err := strconv.Atoi(indexStr)
+			if err != nil {
 				return "", fmt.Errorf("$last: invalid index [%s]", indexStr)
 			}
 			if index < 0 || index >= len(arr) {
@@ -640,6 +644,8 @@ func resolveLastRef(arg string, jsonData interface{}) (string, error) {
 	switch v := value.(type) {
 	case string:
 		valueStr = v
+	case json.Number:
+		valueStr = v.String()
 	case float64:
 		if v == float64(int64(v)) {
 			valueStr = fmt.Sprintf("%d", int64(v))

--- a/internal/cli/repl.go
+++ b/internal/cli/repl.go
@@ -549,9 +549,9 @@ func executeAndCapture(binary string, args []string) commandResult {
 		dec := json.NewDecoder(strings.NewReader(trimmed))
 		dec.UseNumber()
 		if dec.Decode(&parsed) == nil {
-			// Verify no trailing non-whitespace after the JSON value.
+			// Any second-decode result other than io.EOF means trailing content.
 			var extra json.RawMessage
-			if dec.Decode(&extra) != io.EOF && extra != nil {
+			if dec.Decode(&extra) != io.EOF {
 				parsed = nil // trailing content — not clean JSON
 			}
 		} else {

--- a/internal/cli/repl.go
+++ b/internal/cli/repl.go
@@ -548,7 +548,13 @@ func executeAndCapture(binary string, args []string) commandResult {
 	if len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') {
 		dec := json.NewDecoder(strings.NewReader(trimmed))
 		dec.UseNumber()
-		if dec.Decode(&parsed) != nil {
+		if dec.Decode(&parsed) == nil {
+			// Verify no trailing non-whitespace after the JSON value.
+			var extra json.RawMessage
+			if dec.Decode(&extra) != io.EOF && extra != nil {
+				parsed = nil // trailing content — not clean JSON
+			}
+		} else {
 			parsed = nil
 		}
 	}
@@ -626,11 +632,14 @@ func resolveLastRef(arg string, jsonData interface{}) (string, error) {
 			if !ok {
 				return "", fmt.Errorf("$last: cannot index non-array")
 			}
+			if !isDigitsOnly(indexStr) {
+				return "", fmt.Errorf("$last: invalid index [%s]", indexStr)
+			}
 			index, err := strconv.Atoi(indexStr)
 			if err != nil {
 				return "", fmt.Errorf("$last: invalid index [%s]", indexStr)
 			}
-			if index < 0 || index >= len(arr) {
+			if index >= len(arr) {
 				return "", fmt.Errorf("$last: index [%d] out of range (length %d)", index, len(arr))
 			}
 			value = arr[index]
@@ -662,4 +671,17 @@ func resolveLastRef(arg string, jsonData interface{}) (string, error) {
 	}
 
 	return prefix + valueStr + path, nil
+}
+
+// isDigitsOnly returns true if s is non-empty and contains only 0-9.
+func isDigitsOnly(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, ch := range s {
+		if ch < '0' || ch > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/cli/repl.go
+++ b/internal/cli/repl.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -12,6 +15,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// commandResult captures the outcome of a subprocess command.
+type commandResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+	JSON     interface{} // parsed JSON from stdout, nil if not valid JSON
+}
+
 // replContext holds session state across REPL commands.
 type replContext struct {
 	ProjectID       string
@@ -19,11 +30,12 @@ type replContext struct {
 	Location        string
 	Profile         string
 	Agent           string
-	Format          string // session output format (default: text)
-	Token           string // forwarded from parent --token
-	CredentialsFile string // forwarded from parent --credentials-file
-	Retry           int    // forwarded from parent --retry
-	OutputFields    string // forwarded from parent --output-fields
+	Format          string         // session output format (default: text)
+	LastResult      *commandResult // last successful command result ($last)
+	Token           string         // forwarded from parent --token
+	CredentialsFile string         // forwarded from parent --credentials-file
+	Retry           int            // forwarded from parent --retry
+	OutputFields    string         // forwarded from parent --output-fields
 }
 
 // blockedCommands are interactive/server commands that shouldn't run in the REPL.
@@ -143,6 +155,14 @@ func runREPL(app *App, formatExplicit bool) error {
 			continue
 		}
 
+		// Expand $last references in arguments.
+		var expandErr error
+		args, expandErr = expandLastRefs(args, ctx.LastResult)
+		if expandErr != nil {
+			fmt.Fprintf(os.Stderr, "  %s\n", expandErr)
+			continue
+		}
+
 		// Block interactive/server commands.
 		if isBlockedCommand(args) {
 			fmt.Fprintf(os.Stderr, "  command not available in REPL: %s\n", args[0])
@@ -155,13 +175,19 @@ func runREPL(app *App, formatExplicit bool) error {
 		// Append format if not already specified.
 		args = appendFormatIfMissing(args, ctx.Format)
 
-		// Execute as subprocess.
-		execCmd := exec.CommandContext(context.Background(), dcxBinary, args...)
-		execCmd.Stdout = os.Stdout
-		execCmd.Stderr = os.Stderr
-		execCmd.Stdin = os.Stdin
-		execCmd.Run() // ignore exit code — errors printed via stderr
+		// Execute as subprocess with capture.
+		result := executeAndCapture(dcxBinary, args)
 		fmt.Println() // blank line after output for readability
+
+		// Update $last: successful JSON → update; successful non-JSON → clear; error → keep.
+		if result.ExitCode == 0 {
+			if result.JSON != nil {
+				ctx.LastResult = &result
+			} else {
+				ctx.LastResult = nil // non-JSON clears $last
+			}
+		}
+		// On error, LastResult is unchanged (don't lose good state)
 	}
 }
 
@@ -489,4 +515,145 @@ func appendFormatIfMissing(args []string, format string) []string {
 		return args
 	}
 	return append(args, "--format", format)
+}
+
+// executeAndCapture runs a dcx subprocess, streaming stdout/stderr to the
+// terminal in real-time while also capturing them for $last and transcripts.
+func executeAndCapture(binary string, args []string) commandResult {
+	var stdoutBuf, stderrBuf bytes.Buffer
+
+	cmd := exec.CommandContext(context.Background(), binary, args...)
+	cmd.Stdout = io.MultiWriter(os.Stdout, &stdoutBuf)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
+	cmd.Stdin = os.Stdin
+
+	err := cmd.Run()
+
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = 1
+		}
+	}
+
+	stdout := stdoutBuf.String()
+
+	// Try to parse stdout as JSON for $last.
+	var parsed interface{}
+	trimmed := strings.TrimSpace(stdout)
+	if len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') {
+		if json.Unmarshal([]byte(trimmed), &parsed) != nil {
+			parsed = nil
+		}
+	}
+
+	return commandResult{
+		Stdout:   stdout,
+		Stderr:   stderrBuf.String(),
+		ExitCode: exitCode,
+		JSON:     parsed,
+	}
+}
+
+// expandLastRefs replaces $last and $last.path.to.field references in args.
+func expandLastRefs(args []string, last *commandResult) ([]string, error) {
+	result := make([]string, len(args))
+	for i, arg := range args {
+		if !strings.Contains(arg, "$last") {
+			result[i] = arg
+			continue
+		}
+		if last == nil {
+			return nil, fmt.Errorf("$last: no JSON result available; use /format json first")
+		}
+		expanded, err := resolveLastRef(arg, last.JSON)
+		if err != nil {
+			return nil, err
+		}
+		result[i] = expanded
+	}
+	return result, nil
+}
+
+// resolveLastRef resolves a single $last reference within an argument string.
+// Supports: $last, $last.field, $last.field[0], $last.field[0].subfield
+func resolveLastRef(arg string, jsonData interface{}) (string, error) {
+	idx := strings.Index(arg, "$last")
+	if idx < 0 {
+		return arg, nil
+	}
+
+	prefix := arg[:idx]
+	path := arg[idx+5:] // after "$last"
+
+	value := jsonData
+
+	// Parse path segments: .field or [N]
+	for len(path) > 0 {
+		if path[0] == '.' {
+			path = path[1:]
+			// Extract field name (until next . or [ or end)
+			end := strings.IndexAny(path, ".[")
+			if end < 0 {
+				end = len(path)
+			}
+			fieldName := path[:end]
+			path = path[end:]
+
+			m, ok := value.(map[string]interface{})
+			if !ok {
+				return "", fmt.Errorf("$last: cannot access .%s on non-object", fieldName)
+			}
+			value, ok = m[fieldName]
+			if !ok {
+				return "", fmt.Errorf("$last: field %q not found", fieldName)
+			}
+		} else if path[0] == '[' {
+			end := strings.Index(path, "]")
+			if end < 0 {
+				return "", fmt.Errorf("$last: unclosed bracket in path")
+			}
+			indexStr := path[1:end]
+			path = path[end+1:]
+
+			arr, ok := value.([]interface{})
+			if !ok {
+				return "", fmt.Errorf("$last: cannot index non-array")
+			}
+			var index int
+			if _, err := fmt.Sscanf(indexStr, "%d", &index); err != nil {
+				return "", fmt.Errorf("$last: invalid index [%s]", indexStr)
+			}
+			if index < 0 || index >= len(arr) {
+				return "", fmt.Errorf("$last: index [%d] out of range (length %d)", index, len(arr))
+			}
+			value = arr[index]
+		} else {
+			break // remaining text is suffix
+		}
+	}
+
+	// Format the resolved value as a string.
+	var valueStr string
+	switch v := value.(type) {
+	case string:
+		valueStr = v
+	case float64:
+		if v == float64(int64(v)) {
+			valueStr = fmt.Sprintf("%d", int64(v))
+		} else {
+			valueStr = fmt.Sprintf("%g", v)
+		}
+	case bool:
+		valueStr = fmt.Sprintf("%t", v)
+	case nil:
+		valueStr = ""
+	default:
+		data, _ := json.Marshal(v)
+		valueStr = string(data)
+	}
+
+	return prefix + valueStr + path, nil
 }


### PR DESCRIPTION
## Summary

REPL P1 foundation — combines PRs B (capture) and C ($last) from the #47 shipping plan since they're tightly coupled.

### Subprocess capture

`executeAndCapture()` uses `io.MultiWriter` to tee stdout to both the terminal and a buffer. This preserves real-time CA streaming while capturing output for `$last` and future transcript support.

```go
cmd.Stdout = io.MultiWriter(os.Stdout, &stdoutBuf)
cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
```

### `$last` result references

```text
dcx> /format json
dcx> ca list-agents --output-fields=_resource_id,display_name
  {"items":[{"_resource_id":"agent_463...","display_name":"The Look Ecommerce"},...]}

dcx> ca ask "how many orders?" --agent=$last.items[0]._resource_id
  {"question":"how many orders?","agent":"agent_463...","results":{"data":[{"total_order_count":125174}]}}
```

### `$last` rules (per #47 accepted amendments)

| Condition | `$last` behavior |
|---|---|
| Successful + valid JSON stdout | Updated |
| Successful + non-JSON stdout | Cleared |
| Failed command (non-zero exit) | Unchanged |
| `$last` used when unset | Error: "no JSON result available; use /format json first" |

### Path evaluator

| Expression | What it does |
|---|---|
| `$last` | Entire JSON object |
| `$last.field` | Field access |
| `$last.field[0]` | Array index |
| `$last.field[0].sub` | Chained |

No filters, wildcards, or expressions — intentionally minimal.

### Verified

- `ca list-agents` → `$last.items[0]._resource_id` → `ca ask` chains correctly
- Non-JSON output clears `$last`
- Unset `$last` returns clear error
- CA streaming preserved during capture

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes
- [x] `$last` chaining: list-agents → pick ID → ca ask
- [x] Non-JSON clears `$last`
- [x] Failed command preserves `$last`
- [x] Unset `$last` → error message
- [x] CA streaming still visible in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)