### PR TITLE
Add dcx auth login/logout for OAuth2 browser flow

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -77,7 +77,11 @@ func Resolve(ctx context.Context, cfg Config) (*ResolvedAuth, error) {
 	}
 
 	// Tier 3: Stored OAuth credentials (dcx auth login).
-	// Not yet implemented — will use keyring in a future phase.
+	if stored, err := LoadStoredCredentials(ctx); err != nil {
+		return nil, fmt.Errorf("loading stored credentials: %w", err)
+	} else if stored != nil {
+		return stored, nil
+	}
 
 	// Tier 4: GOOGLE_APPLICATION_CREDENTIALS (standard ADC file).
 	if adcFile := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); adcFile != "" {

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -197,7 +197,7 @@ func openBrowser(url string) error {
 	case "linux":
 		return exec.Command("xdg-open", url).Start()
 	case "windows":
-		return exec.Command("cmd", "/c", "start", url).Start()
+		return exec.Command("cmd", "/c", "start", "", url).Start()
 	default:
 		return fmt.Errorf("unsupported platform %s", runtime.GOOS)
 	}

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -7,7 +7,9 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -65,7 +67,13 @@ func Login(ctx context.Context) (*oauth2.Token, error) {
 	state := fmt.Sprintf("dcx-%d", time.Now().UnixNano())
 	authURL := config.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.ApprovalForce)
 
-	fmt.Fprintf(os.Stderr, "\nOpen this URL in your browser to log in:\n\n  %s\n\nWaiting for authorization...\n", authURL)
+	// Try to open the browser automatically; fall back to printing the URL.
+	if err := openBrowser(authURL); err != nil {
+		fmt.Fprintf(os.Stderr, "\nOpen this URL in your browser to log in:\n\n  %s\n\n", authURL)
+	} else {
+		fmt.Fprintf(os.Stderr, "\nOpening browser for authorization...\n(If it doesn't open, visit: %s)\n\n", authURL)
+	}
+	fmt.Fprintf(os.Stderr, "Waiting for authorization...\n")
 
 	// Wait for the redirect with the auth code.
 	codeCh := make(chan string, 1)
@@ -112,9 +120,11 @@ func Login(ctx context.Context) (*oauth2.Token, error) {
 		return nil, fmt.Errorf("token exchange failed: %w", err)
 	}
 
-	// Save the refresh token.
+	// Save the refresh token — fail if we cannot persist, because the user
+	// would get a one-time access token but subsequent commands would still
+	// fall back to ADC.
 	if err := saveCredentials(config, token); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not save credentials: %v\n", err)
+		return nil, fmt.Errorf("saving credentials: %w", err)
 	}
 
 	return token, nil
@@ -147,7 +157,10 @@ func LoadStoredCredentials(ctx context.Context) (*ResolvedAuth, error) {
 	path := credentialsPath()
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, nil // no stored credentials — not an error
+		if os.IsNotExist(err) {
+			return nil, nil // no stored credentials — not an error
+		}
+		return nil, fmt.Errorf("reading stored credentials: %w", err)
 	}
 
 	var creds storedCredentials
@@ -174,6 +187,20 @@ func LoadStoredCredentials(ctx context.Context) (*ResolvedAuth, error) {
 		Source:      path,
 		TokenSource: ts,
 	}, nil
+}
+
+// openBrowser opens the given URL in the user's default browser.
+func openBrowser(url string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", url).Start()
+	case "linux":
+		return exec.Command("xdg-open", url).Start()
+	case "windows":
+		return exec.Command("cmd", "/c", "start", url).Start()
+	default:
+		return fmt.Errorf("unsupported platform %s", runtime.GOOS)
+	}
 }
 
 // Logout removes stored credentials.

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -1,0 +1,186 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+// Default OAuth2 client ID for dcx (desktop app flow).
+// This is a public client ID — the secret is not sensitive for desktop apps.
+const (
+	defaultClientID     = "764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.apps.googleusercontent.com"
+	defaultClientSecret = "d-FL95Q19q7MQmFpd7hHD0Ty"
+)
+
+// OAuthScopes are the scopes requested during dcx auth login.
+var OAuthScopes = []string{
+	"https://www.googleapis.com/auth/cloud-platform",
+	"https://www.googleapis.com/auth/bigquery",
+}
+
+// storedCredentials is the JSON shape saved to ~/.config/dcx/credentials.json.
+type storedCredentials struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+}
+
+// credentialsPath returns the path to ~/.config/dcx/credentials.json.
+func credentialsPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".config", "dcx", "credentials.json")
+}
+
+// Login performs an OAuth2 authorization code flow with a local redirect.
+// Opens the browser for user consent, captures the auth code via a local
+// HTTP server, exchanges it for a refresh token, and saves it to disk.
+func Login(ctx context.Context) (*oauth2.Token, error) {
+	config := &oauth2.Config{
+		ClientID:     defaultClientID,
+		ClientSecret: defaultClientSecret,
+		Scopes:       OAuthScopes,
+		Endpoint:     google.Endpoint,
+		RedirectURL:  "http://localhost:0", // will be set after listener binds
+	}
+
+	// Start a local HTTP server to capture the redirect.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("starting local server: %w", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	config.RedirectURL = fmt.Sprintf("http://localhost:%d", port)
+
+	// Generate the auth URL.
+	state := fmt.Sprintf("dcx-%d", time.Now().UnixNano())
+	authURL := config.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.ApprovalForce)
+
+	fmt.Fprintf(os.Stderr, "\nOpen this URL in your browser to log in:\n\n  %s\n\nWaiting for authorization...\n", authURL)
+
+	// Wait for the redirect with the auth code.
+	codeCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("state") != state {
+			errCh <- fmt.Errorf("state mismatch")
+			http.Error(w, "State mismatch", http.StatusBadRequest)
+			return
+		}
+		if errMsg := r.URL.Query().Get("error"); errMsg != "" {
+			errCh <- fmt.Errorf("authorization denied: %s", errMsg)
+			fmt.Fprintf(w, "<html><body><h2>Authorization denied</h2><p>%s</p><p>You can close this tab.</p></body></html>", errMsg)
+			return
+		}
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			errCh <- fmt.Errorf("no authorization code received")
+			http.Error(w, "No code", http.StatusBadRequest)
+			return
+		}
+		codeCh <- code
+		fmt.Fprint(w, "<html><body><h2>dcx authorized</h2><p>You can close this tab and return to the terminal.</p></body></html>")
+	})
+
+	server := &http.Server{Handler: mux}
+	go server.Serve(listener)
+	defer server.Close()
+
+	var code string
+	select {
+	case code = <-codeCh:
+	case err := <-errCh:
+		return nil, err
+	case <-time.After(120 * time.Second):
+		return nil, fmt.Errorf("authorization timed out after 120 seconds")
+	}
+
+	// Exchange the code for a token.
+	token, err := config.Exchange(ctx, code)
+	if err != nil {
+		return nil, fmt.Errorf("token exchange failed: %w", err)
+	}
+
+	// Save the refresh token.
+	if err := saveCredentials(config, token); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not save credentials: %v\n", err)
+	}
+
+	return token, nil
+}
+
+// saveCredentials writes the refresh token to ~/.config/dcx/credentials.json.
+func saveCredentials(config *oauth2.Config, token *oauth2.Token) error {
+	creds := storedCredentials{
+		ClientID:     config.ClientID,
+		ClientSecret: config.ClientSecret,
+		RefreshToken: token.RefreshToken,
+		TokenType:    "authorized_user",
+	}
+
+	data, err := json.MarshalIndent(creds, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	path := credentialsPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+// LoadStoredCredentials loads saved OAuth credentials from disk and returns
+// a TokenSource. Returns nil if no stored credentials exist.
+func LoadStoredCredentials(ctx context.Context) (*ResolvedAuth, error) {
+	path := credentialsPath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil // no stored credentials — not an error
+	}
+
+	var creds storedCredentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return nil, fmt.Errorf("parsing stored credentials: %w", err)
+	}
+
+	if creds.RefreshToken == "" {
+		return nil, nil
+	}
+
+	config := &oauth2.Config{
+		ClientID:     creds.ClientID,
+		ClientSecret: creds.ClientSecret,
+		Scopes:       OAuthScopes,
+		Endpoint:     google.Endpoint,
+	}
+
+	token := &oauth2.Token{RefreshToken: creds.RefreshToken}
+	ts := config.TokenSource(ctx, token)
+
+	return &ResolvedAuth{
+		Method:      "stored_oauth",
+		Source:      path,
+		TokenSource: ts,
+	}, nil
+}
+
+// Logout removes stored credentials.
+func Logout() error {
+	path := credentialsPath()
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/haiyuan-eng-google/dcx-cli/internal/auth"
@@ -19,6 +21,8 @@ func (a *App) addAuthCommands() {
 
 	authCmd.AddCommand(a.authCheckCmd())
 	authCmd.AddCommand(a.authStatusCmd())
+	authCmd.AddCommand(a.authLoginCmd())
+	authCmd.AddCommand(a.authLogoutCmd())
 
 	a.Root.AddCommand(authCmd)
 
@@ -31,6 +35,16 @@ func (a *App) addAuthCommands() {
 	a.Registry.Register(contracts.BuildContract(
 		"auth status", "auth",
 		"Show current authentication status",
+		nil, false, false,
+	))
+	a.Registry.Register(contracts.BuildContract(
+		"auth login", "auth",
+		"Log in via OAuth2 browser flow and store credentials",
+		nil, false, false,
+	))
+	a.Registry.Register(contracts.BuildContract(
+		"auth logout", "auth",
+		"Remove stored OAuth2 credentials",
 		nil, false, false,
 	))
 }
@@ -59,6 +73,63 @@ func (a *App) authCheckCmd() *cobra.Command {
 			}
 
 			return a.Render(format, result)
+		},
+	}
+}
+
+func (a *App) authLoginCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "login",
+		Short: "Log in via OAuth2 browser flow and store credentials",
+		Long: `Opens a browser for Google OAuth2 authorization. After consent,
+stores a refresh token in ~/.config/dcx/credentials.json.
+
+Subsequent dcx commands will use this token automatically
+(Tier 3 in the auth resolution chain, after --token and
+--credentials-file but before ADC).`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			token, err := auth.Login(ctx)
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.AuthError, err.Error(), "")
+				return nil
+			}
+
+			fmt.Fprintf(os.Stderr, "Logged in successfully. Credentials saved to ~/.config/dcx/credentials.json\n")
+			fmt.Fprintf(os.Stderr, "Token expires: %s\n", token.Expiry.Format("2006-01-02 15:04:05"))
+
+			format, fmtErr := a.OutputFormat()
+			if fmtErr != nil {
+				return nil
+			}
+			return a.Render(format, map[string]interface{}{
+				"authenticated": true,
+				"method":        "oauth_login",
+				"source":        "~/.config/dcx/credentials.json",
+			})
+		},
+	}
+}
+
+func (a *App) authLogoutCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "logout",
+		Short: "Remove stored OAuth2 credentials",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := auth.Logout(); err != nil {
+				dcxerrors.Emit(dcxerrors.Internal, err.Error(), "")
+				return nil
+			}
+
+			fmt.Fprintf(os.Stderr, "Logged out. Stored credentials removed.\n")
+
+			format, fmtErr := a.OutputFormat()
+			if fmtErr != nil {
+				return nil
+			}
+			return a.Render(format, map[string]interface{}{
+				"logged_out": true,
+			})
 		},
 	}
 }

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -135,7 +135,7 @@ func TestCommandDiscovery(t *testing.T) {
 		"dcx ca create-agent", "dcx ca list-agents", "dcx ca add-verified-query",
 		"dcx ca delete-agent",
 		// Auth
-		"dcx auth check", "dcx auth status",
+		"dcx auth check", "dcx auth status", "dcx auth login", "dcx auth logout",
 		// Profiles
 		"dcx profiles list", "dcx profiles validate", "dcx profiles test",
 		// Meta
@@ -158,8 +158,8 @@ func TestCommandDiscovery(t *testing.T) {
 		}
 	}
 
-	if len(commands) < 86 {
-		t.Errorf("expected at least 86 commands, got %d", len(commands))
+	if len(commands) < 88 {
+		t.Errorf("expected at least 88 commands, got %d", len(commands))
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `dcx auth login` and `dcx auth logout` for interactive OAuth2 authentication (86 → 88 commands). Fixes domain-restricted account issue (#50).

### Usage

```bash
# Log in via browser
dcx auth login
# → Opens browser for Google OAuth2 consent
# → Saves refresh token to ~/.config/dcx/credentials.json

# Verify
dcx auth check
# → authenticated: true, method: stored_oauth

# Use dcx normally — token refreshes automatically
dcx ca ask "describe the data" --project-id=P --tables=P.D.T

# Log out
dcx auth logout
# → Removes stored credentials
```

### Why this is needed

Issue #50: accounts with Google Workspace domain restrictions get `ACCESS_TOKEN_TYPE_UNSUPPORTED` when using ADC tokens (gcloud application-default). The direct OAuth2 browser flow obtains a user-consented token that bypasses this restriction.

### Auth resolution chain (updated)

| Priority | Method | Source |
|---|---|---|
| 1 | `--token` / `DCX_TOKEN` | Static bearer token |
| 2 | `--credentials-file` / `DCX_CREDENTIALS_FILE` | Service account JSON |
| **3** | **`dcx auth login`** | **Stored OAuth refresh token** ← NEW |
| 4 | `GOOGLE_APPLICATION_CREDENTIALS` | Standard ADC file |
| 5 | Default ADC | gcloud / metadata server |

### Design

- Uses Google's public desktop app OAuth client ID (same as gcloud)
- Local HTTP server on `127.0.0.1` captures the redirect
- Refresh token saved to `~/.config/dcx/credentials.json` with 0600 permissions
- 120 second timeout for browser authorization
- Token refreshes automatically on subsequent commands

## Test plan

- [x] `go vet ./...` clean, `go test ./... -count=1` passes
- [x] `auth login` shows in `--help` and `meta commands` (88 total)
- [x] `auth logout` removes credentials file
- [x] Eval test updated for 88 commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)