### PR TITLE
Fix OAuth redirect failing on Linux (IPv4/IPv6 mismatch)

### DIFF
--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -61,7 +61,7 @@ func Login(ctx context.Context) (*oauth2.Token, error) {
 		return nil, fmt.Errorf("starting local server: %w", err)
 	}
 	port := listener.Addr().(*net.TCPAddr).Port
-	config.RedirectURL = fmt.Sprintf("http://localhost:%d", port)
+	config.RedirectURL = fmt.Sprintf("http://127.0.0.1:%d", port)
 
 	// Generate the auth URL.
 	state := fmt.Sprintf("dcx-%d", time.Now().UnixNano())


### PR DESCRIPTION
## Summary

- Fix `dcx auth login` redirect failing on Linux where `localhost` resolves to `::1` (IPv6)
- Server listens on `127.0.0.1` (IPv4) but redirect URL used `http://localhost:PORT` — browser connects via IPv6, misses the server
- Change redirect URL to `http://127.0.0.1:PORT` to match the IPv4 listener

## Root cause

From issue #50 comment: after completing OAuth consent, the browser showed "The webpage at http://localhost:36015/... might be temporarily down" even though the auth code was in the URL. The server was running but only on IPv4, while the browser connected via IPv6.

## Test plan

- [x] `go build`, `go vet`, `go test ./... -count=1` all pass
- [ ] `dcx auth login` on Linux machine redirects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)