### PR TITLE
Fix CA error parsing to surface full API error details

### DIFF
--- a/internal/ca/client.go
+++ b/internal/ca/client.go
@@ -483,14 +483,75 @@ func (c *Client) ListAgents(ctx context.Context, token, projectID, _ string) (*A
 	}, nil
 }
 
+// extractErrorMessage tries multiple JSON error shapes to find a useful message.
 func extractErrorMessage(body []byte, statusCode int) string {
+	// Shape 1: Standard Google API error {"error": {"message": "...", "status": "..."}}
 	var apiErr struct {
 		Error struct {
 			Message string `json:"message"`
+			Code    int    `json:"code"`
+			Status  string `json:"status"`
+			Details []struct {
+				Detail string `json:"detail"`
+				Reason string `json:"reason"`
+			} `json:"details"`
 		} `json:"error"`
 	}
 	if json.Unmarshal(body, &apiErr) == nil && apiErr.Error.Message != "" {
-		return apiErr.Error.Message
+		msg := apiErr.Error.Message
+		for _, d := range apiErr.Error.Details {
+			if d.Reason != "" {
+				msg += " (" + d.Reason + ")"
+				break
+			}
+		}
+		return msg
+	}
+
+	// Shape 2: Array-wrapped error [{"error": {"message": "..."}}]
+	var arrErr []struct {
+		Error struct {
+			Message string `json:"message"`
+			Code    int    `json:"code"`
+			Status  string `json:"status"`
+			Details []struct {
+				Detail string `json:"detail"`
+				Reason string `json:"reason"`
+			} `json:"details"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(body, &arrErr) == nil && len(arrErr) > 0 && arrErr[0].Error.Message != "" {
+		msg := arrErr[0].Error.Message
+		for _, d := range arrErr[0].Error.Details {
+			if d.Reason != "" {
+				msg += " (" + d.Reason + ")"
+				break
+			}
+		}
+		return msg
+	}
+
+	// Shape 3: Flat message {"message": "...", "error": "..."}
+	var flatErr struct {
+		Message string `json:"message"`
+		Error   string `json:"error"`
+	}
+	if json.Unmarshal(body, &flatErr) == nil {
+		if flatErr.Message != "" {
+			return flatErr.Message
+		}
+		if flatErr.Error != "" {
+			return flatErr.Error
+		}
+	}
+
+	// Fallback: include raw body (truncated) so users can debug.
+	raw := string(body)
+	if len(raw) > 200 {
+		raw = raw[:200] + "..."
+	}
+	if raw != "" {
+		return fmt.Sprintf("API returned HTTP %d: %s", statusCode, raw)
 	}
 	return fmt.Sprintf("API returned HTTP %d", statusCode)
 }
@@ -1017,16 +1078,7 @@ func parseBQTableRefMap(ref string) map[string]string {
 
 func readAPIError(resp *http.Response) error {
 	body, _ := io.ReadAll(resp.Body)
-	var apiErr struct {
-		Error struct {
-			Message string `json:"message"`
-			Code    int    `json:"code"`
-		} `json:"error"`
-	}
-	message := fmt.Sprintf("API returned HTTP %d", resp.StatusCode)
-	if json.Unmarshal(body, &apiErr) == nil && apiErr.Error.Message != "" {
-		message = apiErr.Error.Message
-	}
+	message := extractErrorMessage(body, resp.StatusCode)
 	return &dcxerrors.APIHTTPError{StatusCode: resp.StatusCode, Message: message, RetryAfter: resp.Header.Get("Retry-After")}
 }
 


### PR DESCRIPTION
## Summary

- Fix `readAPIError()` to handle multiple JSON error shapes from the Gemini Data Analytics API
- Append `reason` from error details (e.g., `ACCESS_TOKEN_TYPE_UNSUPPORTED`)
- Fall back to raw body (truncated 200 chars) when no known shape matches

Fixes #50.

## Error shapes now handled

| Shape | Example |
|-------|---------|
| Standard Google API | `{"error": {"message": "...", "details": [{"reason": "..."}]}}` |
| Array-wrapped | `[{"error": {"message": "...", "details": [...]}}]` |
| Flat message | `{"message": "..."}` or `{"error": "..."}` |
| Unknown | Raw body truncated to 200 chars |

## Before/After

**Before:**
```json
{"error":{"code":"API_ERROR","message":"API returned HTTP 400"}}
```

**After:**
```json
{"error":{"code":"API_ERROR","message":"Request had invalid authentication credentials. Expected OAuth 2 access token... (ACCESS_TOKEN_TYPE_UNSUPPORTED)"}}
```

## Test plan

- [x] `go test ./... -count=1` all pass
- [x] `go build` clean
- [x] Verified with real API error (domain-restricted account returns detailed message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)