### PR TITLE
Fix 4 dogfooding findings: renderer, fields, format validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An agent-native CLI for Google Cloud's Data Cloud, built in Go.
 One binary for BigQuery, Spanner, AlloyDB, Cloud SQL, and Looker —
 with structured output, typed errors, and an MCP bridge for AI agents.
 
-> **Status:** Go MVP functional — 86 commands across 11 domains.
+> **Status:** Go MVP functional — 88 commands across 11 domains.
 > Benchmarked at **5x faster** than `bq` with token cost within 6%.
 > See [docs/benchmark_results.md](docs/benchmark_results.md)
 > for measured results.
@@ -47,6 +47,17 @@ dcx ca ask "top errors yesterday" --profile my-spanner-profile
 dcx ca create-agent --name=sales-agent --tables=myproject.sales.orders --project-id=myproject
 dcx ca ask "revenue by region this quarter" --agent=sales-agent --project-id=myproject
 
+# SQL queries render as tables in text/table format
+dcx jobs query --query="SELECT event_type, COUNT(*) as cnt FROM events GROUP BY 1 LIMIT 5" --format=text
+# → event_type   | cnt
+#   -------------+----
+#   LLM_RESPONSE | 54
+#   LLM_REQUEST  | 52
+#   (5 rows)
+
+# Interactive REPL for iterative exploration
+dcx repl --project-id=myproject --location=us
+
 # Enable shell completions (bash/zsh/fish/powershell)
 source <(dcx completion bash)
 
@@ -54,7 +65,34 @@ source <(dcx completion bash)
 dcx mcp serve
 ```
 
-## Commands (86 total)
+## Interactive REPL
+
+`dcx repl` provides an interactive session with context persistence,
+tab completion, bare SQL routing, and result chaining:
+
+```
+dcx> set dataset analytics
+dcx> tables list
+dcx> SELECT event_type, COUNT(*) as cnt FROM `proj.analytics.events` GROUP BY 1 LIMIT 5;
+
+event_type   | cnt
+-------------+----
+LLM_RESPONSE | 54
+LLM_REQUEST  | 52
+(5 rows)
+
+dcx> /format json
+dcx> datasets list
+dcx> tables list --dataset-id=$last.items[0]._resource_id
+dcx> ca create-agent --name=my-agent --tables=proj.analytics.events
+dcx> set agent my-agent
+dcx> ca ask "top errors yesterday"
+```
+
+Features: tab completion, `$last` result references, `/output-fields` toggle,
+`/transcript start/stop`, DML/DDL safety (`run`/`dry-run`), Ctrl-C signal handling.
+
+## Commands (88 total)
 
 | Surface | Commands |
 |---|---|
@@ -64,7 +102,7 @@ dcx mcp serve
 | **Cloud SQL** | `instances list/get`, `databases list/get/insert/delete`, `backupRuns list/get`, `users list/get/insert/delete`, `operations list/get`, `flags list`, `tiers list`, `schema describe` |
 | **Looker** | `instances list/get`, `backups list/get`, `explores list`, `dashboards get` |
 | **CA** | `ca ask`, `ca create-agent`, `ca list-agents`, `ca add-verified-query`, `ca delete-agent` |
-| **Auth** | `auth status`, `auth check` |
+| **Auth** | `auth status`, `auth check`, `auth login`, `auth logout` |
 | **Profiles** | `profiles list`, `profiles validate`, `profiles test` |
 | **Introspection** | `meta commands`, `meta describe`, `meta generate-skills`, `meta schema` |
 | **MCP** | `mcp serve` (JSON-RPC 2.0 / stdio, read-only, default `json-minified`) |
@@ -111,9 +149,20 @@ Five methods in priority order:
 |----------|--------|----------|
 | 1 | `DCX_TOKEN` env var / `--token` | Pre-obtained access token |
 | 2 | `DCX_CREDENTIALS_FILE` / `--credentials-file` | Service account JSON |
-| 3 | `dcx auth login` | Interactive OAuth (P1) |
+| 3 | `dcx auth login` | Interactive OAuth2 browser flow |
 | 4 | `GOOGLE_APPLICATION_CREDENTIALS` | Standard ADC |
 | 5 | `gcloud auth application-default` | Implicit gcloud credentials |
+
+```bash
+# Log in via browser (stores refresh token to ~/.config/dcx/credentials.json)
+dcx auth login
+
+# Verify
+dcx auth check
+
+# Log out (removes stored credentials)
+dcx auth logout
+```
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ dcx ca create-agent --name=sales-agent --tables=myproject.sales.orders --project
 dcx ca ask "revenue by region this quarter" --agent=sales-agent --project-id=myproject
 
 # SQL queries render as tables in text/table format
-dcx jobs query --query="SELECT event_type, COUNT(*) as cnt FROM events GROUP BY 1 LIMIT 5" --format=text
+dcx jobs query --project-id=myproject --query="SELECT event_type, COUNT(*) as cnt FROM \`myproject.mydataset.events\` GROUP BY 1 LIMIT 5" --format=text
 # → event_type   | cnt
 #   -------------+----
 #   LLM_RESPONSE | 54
@@ -71,9 +71,11 @@ dcx mcp serve
 tab completion, bare SQL routing, and result chaining:
 
 ```
+dcx> set project myproject
 dcx> set dataset analytics
+dcx> set location us
 dcx> tables list
-dcx> SELECT event_type, COUNT(*) as cnt FROM `proj.analytics.events` GROUP BY 1 LIMIT 5;
+dcx> SELECT event_type, COUNT(*) as cnt FROM `myproject.analytics.events` GROUP BY 1 LIMIT 5;
 
 event_type   | cnt
 -------------+----
@@ -84,7 +86,7 @@ LLM_REQUEST  | 52
 dcx> /format json
 dcx> datasets list
 dcx> tables list --dataset-id=$last.items[0]._resource_id
-dcx> ca create-agent --name=my-agent --tables=proj.analytics.events
+dcx> ca create-agent --name=my-agent --tables=myproject.analytics.events
 dcx> set agent my-agent
 dcx> ca ask "top errors yesterday"
 ```

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 
 	"golang.org/x/oauth2"
@@ -138,7 +139,7 @@ func Check(ctx context.Context, cfg Config) StatusResult {
 	}
 
 	// Try to obtain a token to verify credentials work.
-	_, tokenErr := resolved.TokenSource.Token()
+	tok, tokenErr := resolved.TokenSource.Token()
 	if tokenErr != nil {
 		return StatusResult{
 			Authenticated: false,
@@ -148,10 +149,44 @@ func Check(ctx context.Context, cfg Config) StatusResult {
 		}
 	}
 
+	// For static bearer tokens, Token() always succeeds (just returns the
+	// string). Verify with a live tokeninfo call to catch invalid tokens.
+	// Skip verification if DCX_SKIP_TOKEN_VERIFY is set (for testing).
+	if resolved.Method == "token" && os.Getenv("DCX_SKIP_TOKEN_VERIFY") == "" {
+		if err := verifyToken(ctx, tok.AccessToken); err != nil {
+			return StatusResult{
+				Authenticated: false,
+				Method:        resolved.Method,
+				Source:        resolved.Source,
+				Error:         err.Error(),
+			}
+		}
+	}
+
 	return StatusResult{
 		Authenticated: true,
 		Method:        resolved.Method,
 		Source:        resolved.Source,
 		ProjectID:     resolved.ProjectID,
 	}
+}
+
+// HTTPClient is the client used for token verification. Tests can override this.
+var HTTPClient = http.DefaultClient
+
+// verifyToken makes a lightweight tokeninfo call to verify the token is valid.
+func verifyToken(ctx context.Context, token string) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://oauth2.googleapis.com/tokeninfo?access_token="+token, nil)
+	if err != nil {
+		return fmt.Errorf("token verification failed: %w", err)
+	}
+	resp, err := HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("token verification failed: %w", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("token is invalid or expired (tokeninfo returned HTTP %d)", resp.StatusCode)
+	}
+	return nil
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -12,8 +12,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
+	"strings"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -176,13 +178,16 @@ var HTTPClient = http.DefaultClient
 
 // verifyToken makes a lightweight tokeninfo call to verify the token is valid.
 func verifyToken(ctx context.Context, token string) error {
-	req, err := http.NewRequestWithContext(ctx, "GET", "https://oauth2.googleapis.com/tokeninfo?access_token="+token, nil)
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://oauth2.googleapis.com/tokeninfo", nil)
 	if err != nil {
-		return fmt.Errorf("token verification failed: %w", err)
+		return fmt.Errorf("token verification request failed")
 	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Body = io.NopCloser(strings.NewReader("access_token=" + token))
 	resp, err := HTTPClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("token verification failed: %w", err)
+		// Don't wrap the error — it may contain the URL or request details.
+		return fmt.Errorf("token verification failed (network error)")
 	}
 	resp.Body.Close()
 	if resp.StatusCode != 200 {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -182,8 +183,9 @@ func verifyToken(ctx context.Context, token string) error {
 	if err != nil {
 		return fmt.Errorf("token verification request failed")
 	}
+	body := url.Values{"access_token": {token}}.Encode()
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Body = io.NopCloser(strings.NewReader("access_token=" + token))
+	req.Body = io.NopCloser(strings.NewReader(body))
 	resp, err := HTTPClient.Do(req)
 	if err != nil {
 		// Don't wrap the error — it may contain the URL or request details.

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -79,16 +81,67 @@ func TestResolveCredentialsFileNotFound(t *testing.T) {
 }
 
 func TestCheckWithStaticToken(t *testing.T) {
+	// Mock tokeninfo endpoint to return 200 for valid tokens.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(`{"scope":"openid"}`))
+	}))
+	defer srv.Close()
+	origClient := HTTPClient
+	HTTPClient = srv.Client()
+	defer func() { HTTPClient = origClient }()
+
+	// Patch the tokeninfo URL via a test server — we need to override
+	// verifyToken's URL. Since we can't easily do that, use a transport
+	// that redirects to the test server.
+	HTTPClient = &http.Client{
+		Transport: &tokenTestTransport{url: srv.URL},
+	}
+
 	ctx := context.Background()
 	cfg := Config{Token: "test-token"}
 
 	result := Check(ctx, cfg)
 	if !result.Authenticated {
-		t.Errorf("Authenticated = false, want true (static token should succeed)")
+		t.Errorf("Authenticated = false, want true (static token should succeed with valid tokeninfo)")
 	}
 	if result.Method != "token" {
 		t.Errorf("Method = %s, want 'token'", result.Method)
 	}
+}
+
+func TestCheckWithInvalidStaticToken(t *testing.T) {
+	// Mock tokeninfo endpoint to return 400 for invalid tokens.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		w.Write([]byte(`{"error":"invalid_token"}`))
+	}))
+	defer srv.Close()
+	HTTPClient = &http.Client{
+		Transport: &tokenTestTransport{url: srv.URL},
+	}
+	defer func() { HTTPClient = http.DefaultClient }()
+
+	ctx := context.Background()
+	cfg := Config{Token: "bad-token"}
+
+	result := Check(ctx, cfg)
+	if result.Authenticated {
+		t.Errorf("Authenticated = true, want false for invalid static token")
+	}
+	if result.Error == "" {
+		t.Errorf("Error should describe token verification failure")
+	}
+}
+
+// tokenTestTransport redirects all requests to the test server URL.
+type tokenTestTransport struct {
+	url string
+}
+
+func (t *tokenTestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	newReq, _ := http.NewRequestWithContext(req.Context(), req.Method, t.url+req.URL.Path+"?"+req.URL.RawQuery, req.Body)
+	return http.DefaultTransport.RoundTrip(newReq)
 }
 
 func TestCheckWithNoCredentials(t *testing.T) {

--- a/internal/cli/profiles.go
+++ b/internal/cli/profiles.go
@@ -87,8 +87,9 @@ func (a *App) profilesListCmd() *cobra.Command {
 
 func (a *App) profilesValidateCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "validate",
-		Short: "Validate all configured source profiles",
+		Use:   "validate [profile-name]",
+		Short: "Validate source profiles (all or a specific one)",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			format, err := a.OutputFormat()
 			if err != nil {
@@ -100,6 +101,23 @@ func (a *App) profilesValidateCmd() *cobra.Command {
 			if err != nil {
 				dcxerrors.Emit(dcxerrors.InvalidConfig, err.Error(), "Check "+profiles.ProfilesDir())
 				return nil
+			}
+
+			// Filter to specific profile if name given.
+			if len(args) == 1 {
+				name := args[0]
+				var found bool
+				for _, p := range all {
+					if p.Name == name {
+						all = []profiles.Profile{p}
+						found = true
+						break
+					}
+				}
+				if !found {
+					dcxerrors.Emit(dcxerrors.NotFound, "profile not found: "+name, "Run 'dcx profiles list' to see available profiles")
+					return nil
+				}
 			}
 
 			var results []profiles.ValidationResult

--- a/internal/cli/profiles.go
+++ b/internal/cli/profiles.go
@@ -97,13 +97,8 @@ func (a *App) profilesValidateCmd() *cobra.Command {
 				return nil
 			}
 
-			all, err := profiles.LoadAll()
-			if err != nil {
-				dcxerrors.Emit(dcxerrors.InvalidConfig, err.Error(), "Check "+profiles.ProfilesDir())
-				return nil
-			}
-
-			// Filter to specific profile if name given (supports filename, YAML name, or path).
+			// Load specific profile or all profiles.
+			var all []profiles.Profile
 			if len(args) == 1 {
 				p, err := profiles.LoadByName(args[0])
 				if err != nil {
@@ -111,6 +106,13 @@ func (a *App) profilesValidateCmd() *cobra.Command {
 					return nil
 				}
 				all = []profiles.Profile{*p}
+			} else {
+				var err error
+				all, err = profiles.LoadAll()
+				if err != nil {
+					dcxerrors.Emit(dcxerrors.InvalidConfig, err.Error(), "Check "+profiles.ProfilesDir())
+					return nil
+				}
 			}
 
 			var results []profiles.ValidationResult

--- a/internal/cli/profiles.go
+++ b/internal/cli/profiles.go
@@ -103,21 +103,14 @@ func (a *App) profilesValidateCmd() *cobra.Command {
 				return nil
 			}
 
-			// Filter to specific profile if name given.
+			// Filter to specific profile if name given (supports filename, YAML name, or path).
 			if len(args) == 1 {
-				name := args[0]
-				var found bool
-				for _, p := range all {
-					if p.Name == name {
-						all = []profiles.Profile{p}
-						found = true
-						break
-					}
-				}
-				if !found {
-					dcxerrors.Emit(dcxerrors.NotFound, "profile not found: "+name, "Run 'dcx profiles list' to see available profiles")
+				p, err := profiles.LoadByName(args[0])
+				if err != nil {
+					dcxerrors.Emit(dcxerrors.NotFound, err.Error(), "Run 'dcx profiles list' to see available profiles")
 					return nil
 				}
+				all = []profiles.Profile{*p}
 			}
 
 			var results []profiles.ValidationResult

--- a/internal/cli/repl.go
+++ b/internal/cli/repl.go
@@ -268,8 +268,14 @@ func handleBuiltin(input string, ctx *replContext) bool {
 	}
 
 	if strings.HasPrefix(lower, "/format ") {
-		ctx.Format = strings.TrimSpace(input[8:])
-		fmt.Fprintf(os.Stderr, "  format: %s\n", ctx.Format)
+		candidate := strings.TrimSpace(input[8:])
+		switch candidate {
+		case "json", "json-minified", "table", "text":
+			ctx.Format = candidate
+			fmt.Fprintf(os.Stderr, "  format: %s\n", ctx.Format)
+		default:
+			fmt.Fprintf(os.Stderr, "  invalid format %q; valid: json, json-minified, table, text\n", candidate)
+		}
 		return true
 	}
 

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -49,6 +49,7 @@ func cleanEnv() []string {
 	return []string{
 		"PATH=" + os.Getenv("PATH"),
 		"HOME=/tmp/dcx-eval-nonexistent",
+		"DCX_SKIP_TOKEN_VERIFY=1",
 	}
 }
 

--- a/internal/output/fields.go
+++ b/internal/output/fields.go
@@ -85,15 +85,24 @@ func filterValue(raw interface{}, fields map[string]bool) interface{} {
 }
 
 func filterListEnvelope(envelope map[string]interface{}, items []interface{}, fields map[string]bool) map[string]interface{} {
-	// Envelope keys to always preserve.
+	// Always-preserved envelope metadata keys.
 	envelopeKeys := map[string]bool{
 		"source": true, "next_page_token": true, "items": true,
 	}
 
 	result := make(map[string]interface{})
 	for k, v := range envelope {
-		if envelopeKeys[k] {
+		// Preserve structural keys and any envelope field the user requested.
+		if envelopeKeys[k] || fields[k] {
 			result[k] = v
+		}
+	}
+
+	// Check which requested fields matched at envelope level.
+	envelopeMatched := 0
+	for f := range fields {
+		if _, ok := envelope[f]; ok {
+			envelopeMatched++
 		}
 	}
 
@@ -103,7 +112,8 @@ func filterListEnvelope(envelope map[string]interface{}, items []interface{}, fi
 	for _, item := range items {
 		if m, ok := item.(map[string]interface{}); ok {
 			fm := filterMap(m, fields)
-			if !warned && len(fm) == 0 && len(m) > 0 {
+			// Only warn if no fields matched at either envelope or item level.
+			if !warned && len(fm) == 0 && len(m) > 0 && envelopeMatched == 0 {
 				warnNoFieldMatch(m, fields)
 				warned = true
 			}

--- a/internal/output/fields.go
+++ b/internal/output/fields.go
@@ -2,6 +2,8 @@ package output
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
 	"strings"
 )
 
@@ -50,7 +52,11 @@ func filterValue(raw interface{}, fields map[string]bool) interface{} {
 		filtered := make([]interface{}, 0, len(arr))
 		for _, item := range arr {
 			if m, ok := item.(map[string]interface{}); ok {
-				filtered = append(filtered, filterMap(m, fields))
+				result := filterMap(m, fields)
+				if len(result) == 0 && len(filtered) == 0 {
+					warnNoFieldMatch(m, fields)
+				}
+				filtered = append(filtered, result)
 			} else {
 				filtered = append(filtered, item)
 			}
@@ -71,7 +77,11 @@ func filterValue(raw interface{}, fields map[string]bool) interface{} {
 	}
 
 	// Single object: keep only matching keys.
-	return filterMap(m, fields)
+	result := filterMap(m, fields)
+	if len(result) == 0 && len(m) > 0 {
+		warnNoFieldMatch(m, fields)
+	}
+	return result
 }
 
 func filterListEnvelope(envelope map[string]interface{}, items []interface{}, fields map[string]bool) map[string]interface{} {
@@ -109,4 +119,25 @@ func filterMap(m map[string]interface{}, fields map[string]bool) map[string]inte
 		}
 	}
 	return result
+}
+
+// warnNoFieldMatch emits a one-time stderr warning when --output-fields
+// matched nothing in the top-level object.
+var fieldWarnEmitted bool
+
+func warnNoFieldMatch(m map[string]interface{}, fields map[string]bool) {
+	if fieldWarnEmitted {
+		return
+	}
+	available := make([]string, 0, len(m))
+	for k := range m {
+		available = append(available, k)
+	}
+	requested := make([]string, 0, len(fields))
+	for k := range fields {
+		requested = append(requested, k)
+	}
+	fmt.Fprintf(os.Stderr, "warning: --output-fields %s matched no fields (available: %s)\n",
+		strings.Join(requested, ","), strings.Join(available, ", "))
+	fieldWarnEmitted = true
 }

--- a/internal/output/fields.go
+++ b/internal/output/fields.go
@@ -99,9 +99,15 @@ func filterListEnvelope(envelope map[string]interface{}, items []interface{}, fi
 
 	// Filter each item.
 	filtered := make([]interface{}, 0, len(items))
+	warned := false
 	for _, item := range items {
 		if m, ok := item.(map[string]interface{}); ok {
-			filtered = append(filtered, filterMap(m, fields))
+			fm := filterMap(m, fields)
+			if !warned && len(fm) == 0 && len(m) > 0 {
+				warnNoFieldMatch(m, fields)
+				warned = true
+			}
+			filtered = append(filtered, fm)
 		} else {
 			filtered = append(filtered, item)
 		}

--- a/internal/output/fields.go
+++ b/internal/output/fields.go
@@ -45,6 +45,19 @@ func parseFieldSet(fields string) map[string]bool {
 }
 
 func filterValue(raw interface{}, fields map[string]bool) interface{} {
+	// Bare array: filter each element.
+	if arr, ok := raw.([]interface{}); ok {
+		filtered := make([]interface{}, 0, len(arr))
+		for _, item := range arr {
+			if m, ok := item.(map[string]interface{}); ok {
+				filtered = append(filtered, filterMap(m, fields))
+			} else {
+				filtered = append(filtered, item)
+			}
+		}
+		return filtered
+	}
+
 	m, ok := raw.(map[string]interface{})
 	if !ok {
 		return raw

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -330,9 +330,22 @@ func formatScalar(v interface{}) string {
 
 // isBQQueryResult checks if value has the BigQuery query response shape:
 // {"rows": [...], "schema": {"fields": [...]}, "totalRows": "N"}
+// Requires at least one query-response discriminator beyond just schema.fields
+// to avoid false-triggering on schema-only objects.
 func isBQQueryResult(value interface{}) (headers []string, rows [][]string, totalRows string, ok bool) {
 	m, isMap := value.(map[string]interface{})
 	if !isMap {
+		return nil, nil, "", false
+	}
+
+	// Require at least one query-response discriminator to avoid matching
+	// arbitrary objects that happen to have schema.fields (e.g., --output-fields=schema).
+	_, hasRows := m["rows"]
+	_, hasTotalRows := m["totalRows"]
+	_, hasJobComplete := m["jobComplete"]
+	_, hasJobRef := m["jobReference"]
+	_, hasCacheHit := m["cacheHit"]
+	if !hasRows && !hasTotalRows && !hasJobComplete && !hasJobRef && !hasCacheHit {
 		return nil, nil, "", false
 	}
 
@@ -405,13 +418,22 @@ func isBQQueryResult(value interface{}) (headers []string, rows [][]string, tota
 			if v == nil {
 				cells[i] = "NULL"
 			} else {
-				cells[i] = Sanitize(fmt.Sprintf("%v", v))
+				cells[i] = escapeCellValue(Sanitize(fmt.Sprintf("%v", v)))
 			}
 		}
 		rows = append(rows, cells)
 	}
 
 	return headers, rows, totalRows, true
+}
+
+// escapeCellValue replaces newlines and tabs with visible escape sequences
+// for tabular display. Keeps raw values unchanged for JSON formats.
+func escapeCellValue(s string) string {
+	s = strings.ReplaceAll(s, "\n", "\\n")
+	s = strings.ReplaceAll(s, "\r", "\\r")
+	s = strings.ReplaceAll(s, "\t", "\\t")
+	return s
 }
 
 // renderBQQueryTable renders a BQ query result as a formatted table.


### PR DESCRIPTION
## Summary

Fixes all 7 dogfooding findings from issue #41:

| # | Finding | Fix |
|---|---------|-----|
| 1 | `auth check` false-positive for static tokens | Live tokeninfo verification for `method=token` |
| 2 | `meta commands` ignores `--output-fields` | `FilterFields` handles bare arrays |
| 3 | REPL `/format` accepts invalid values | Validate against supported formats, reject with hint |
| 4 | Invalid `--output-fields` renders `{}` silently | One-time stderr warning with available fields |
| 5 | Newline in query value breaks table alignment | Escape `\n`/`\r`/`\t` as visible sequences in cells |
| 6 | `profiles validate <name>` ignores argument | Support optional profile name, error if not found |
| 7 | `--output-fields=schema` false-triggers BQ renderer | Require query-response discriminator field |

## Before/After

**#1:** `DCX_TOKEN=bad-token dcx auth check`
- Before: `{"authenticated":true}` (false positive)
- After: `{"authenticated":false,"error":"token is invalid or expired (tokeninfo returned HTTP 400)"}`

**#2:** `dcx meta commands --output-fields=command`
- Before: Full objects with all fields
- After: `[{"command":"dcx alloydb backups get"},...]`

**#3:** REPL `/format xml`
- Before: Silently sets, next command fails
- After: `invalid format "xml"; valid: json, json-minified, table, text`

**#4:** `dcx auth status --output-fields=does_not_exist`
- Before: `{}` (silent)
- After: `warning: --output-fields does_not_exist matched no fields (available: authenticated, method, source)` + `{}`

**#5:** `SELECT 'line1\nline2' as x --format text`
- Before: Row split across lines, misaligned
- After: `line1\nline2 | 42`

**#6:** `dcx profiles validate nonexistent_profile`
- Before: Exits 0, validates all profiles
- After: `NOT_FOUND: profile not found: nonexistent_profile`

**#7:** `dcx tables get --output-fields=schema --format text`
- Before: `(0 rows)` (false BQ query detection)
- After: Normal schema rendering

## Test plan

- [x] `gofmt`, `go build`, `go vet`, `go test ./... -count=1` all pass
- [x] Invalid static token now fails auth check
- [x] meta commands respects --output-fields
- [x] REPL /format validates input
- [x] Invalid output-fields shows warning
- [x] Newlines escaped in query cells
- [x] profiles validate with name errors on unknown
- [x] Schema-only output not treated as query result

🤖 Generated with [Claude Code](https://claude.com/claude-code)