### PR TITLE
Render CA result data as inline table in text format

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -276,6 +276,10 @@ func renderTextValue(w *os.File, value interface{}, indent int) {
 
 	switch v := value.(type) {
 	case map[string]interface{}:
+		// Check for CA result shape: {data: [...], schema: {fields: [...]}}
+		if renderCAResultTable(w, v, prefix) {
+			return
+		}
 		keys := make([]string, 0, len(v))
 		for k := range v {
 			keys = append(keys, k)
@@ -434,6 +438,124 @@ func escapeCellValue(s string) string {
 	s = strings.ReplaceAll(s, "\r", "\\r")
 	s = strings.ReplaceAll(s, "\t", "\\t")
 	return s
+}
+
+// renderCAResultTable detects the CA result shape {data: [...], schema: {fields: [...]}}
+// and renders the data array as an inline table. Returns true if it handled the rendering.
+func renderCAResultTable(w *os.File, m map[string]interface{}, prefix string) bool {
+	dataRaw, hasData := m["data"]
+	schemaRaw, hasSchema := m["schema"]
+	if !hasData || !hasSchema {
+		return false
+	}
+	data, dataOk := dataRaw.([]interface{})
+	if !dataOk || len(data) == 0 {
+		return false
+	}
+	schema, schemaOk := schemaRaw.(map[string]interface{})
+	if !schemaOk {
+		return false
+	}
+	fieldsRaw, hasFields := schema["fields"]
+	if !hasFields {
+		return false
+	}
+	fields, fieldsOk := fieldsRaw.([]interface{})
+	if !fieldsOk || len(fields) == 0 {
+		return false
+	}
+	// First row must be a map (flat row objects).
+	if _, ok := data[0].(map[string]interface{}); !ok {
+		return false
+	}
+
+	// Extract column names from schema.fields.
+	var headers []string
+	for _, f := range fields {
+		fm, ok := f.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		name, _ := fm["name"].(string)
+		if name == "" {
+			return false
+		}
+		headers = append(headers, Sanitize(name))
+	}
+
+	// Extract rows.
+	var rows [][]string
+	for _, item := range data {
+		row, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		cells := make([]string, len(headers))
+		for i, h := range headers {
+			v, exists := row[h]
+			if !exists || v == nil {
+				cells[i] = "NULL"
+			} else {
+				cells[i] = escapeCellValue(Sanitize(fmt.Sprintf("%v", v)))
+			}
+		}
+		rows = append(rows, cells)
+	}
+
+	// Render as aligned text table.
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = len(h)
+	}
+	for _, row := range rows {
+		for i, cell := range row {
+			if len(cell) > widths[i] {
+				widths[i] = len(cell)
+			}
+		}
+	}
+
+	// Print header.
+	var line strings.Builder
+	for i, h := range headers {
+		if i > 0 {
+			line.WriteString(" | ")
+		}
+		line.WriteString(fmt.Sprintf("%-*s", widths[i], h))
+	}
+	fmt.Fprintf(w, "%s%s\n", prefix, line.String())
+
+	// Separator.
+	line.Reset()
+	for i, wi := range widths {
+		if i > 0 {
+			line.WriteString("-+-")
+		}
+		line.WriteString(strings.Repeat("-", wi))
+	}
+	fmt.Fprintf(w, "%s%s\n", prefix, line.String())
+
+	// Rows.
+	for _, row := range rows {
+		line.Reset()
+		for i, cell := range row {
+			if i > 0 {
+				line.WriteString(" | ")
+			}
+			line.WriteString(fmt.Sprintf("%-*s", widths[i], cell))
+		}
+		fmt.Fprintf(w, "%s%s\n", prefix, line.String())
+	}
+	fmt.Fprintf(w, "%s(%d rows)\n", prefix, len(rows))
+
+	// Also render other keys in the map (name, etc.) if present.
+	for k, v := range m {
+		if k == "data" || k == "schema" {
+			continue
+		}
+		fmt.Fprintf(w, "%s%s: %s\n", prefix, Sanitize(k), Sanitize(formatScalar(v)))
+	}
+	return true
 }
 
 // renderBQQueryTable renders a BQ query result as a formatted table.

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -449,7 +449,7 @@ func renderCAResultTable(w *os.File, m map[string]interface{}, prefix string) bo
 		return false
 	}
 	data, dataOk := dataRaw.([]interface{})
-	if !dataOk || len(data) == 0 {
+	if !dataOk {
 		return false
 	}
 	schema, schemaOk := schemaRaw.(map[string]interface{})
@@ -464,9 +464,11 @@ func renderCAResultTable(w *os.File, m map[string]interface{}, prefix string) bo
 	if !fieldsOk || len(fields) == 0 {
 		return false
 	}
-	// First row must be a map (flat row objects).
-	if _, ok := data[0].(map[string]interface{}); !ok {
-		return false
+	// Non-empty data must have map rows.
+	if len(data) > 0 {
+		if _, ok := data[0].(map[string]interface{}); !ok {
+			return false
+		}
 	}
 
 	// Extract column names from schema.fields.
@@ -481,6 +483,13 @@ func renderCAResultTable(w *os.File, m map[string]interface{}, prefix string) bo
 			return false
 		}
 		headers = append(headers, Sanitize(name))
+	}
+
+	// Handle zero-row case.
+	if len(data) == 0 {
+		fmt.Fprintf(w, "%s(0 rows)\n", prefix)
+		renderCAMetadata(w, m, prefix)
+		return true
 	}
 
 	// Extract rows.
@@ -548,14 +557,26 @@ func renderCAResultTable(w *os.File, m map[string]interface{}, prefix string) bo
 	}
 	fmt.Fprintf(w, "%s(%d rows)\n", prefix, len(rows))
 
-	// Also render other keys in the map (name, etc.) if present.
+	renderCAMetadata(w, m, prefix)
+	return true
+}
+
+// renderCAMetadata renders non-data/schema keys from a CA result map.
+func renderCAMetadata(w *os.File, m map[string]interface{}, prefix string) {
+	// Determine indent level from prefix.
+	indent := len(prefix) / 2
 	for k, v := range m {
 		if k == "data" || k == "schema" {
 			continue
 		}
-		fmt.Fprintf(w, "%s%s: %s\n", prefix, Sanitize(k), Sanitize(formatScalar(v)))
+		switch v.(type) {
+		case map[string]interface{}, []interface{}:
+			fmt.Fprintf(w, "%s%s:\n", prefix, Sanitize(k))
+			renderTextValue(w, v, indent+1)
+		default:
+			fmt.Fprintf(w, "%s%s: %s\n", prefix, Sanitize(k), Sanitize(formatScalar(v)))
+		}
 	}
-	return true
 }
 
 // renderBQQueryTable renders a BQ query result as a formatted table.

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -563,12 +563,19 @@ func renderCAResultTable(w *os.File, m map[string]interface{}, prefix string) bo
 
 // renderCAMetadata renders non-data/schema keys from a CA result map.
 func renderCAMetadata(w *os.File, m map[string]interface{}, prefix string) {
-	// Determine indent level from prefix.
-	indent := len(prefix) / 2
-	for k, v := range m {
+	// Collect and sort keys for stable output.
+	keys := make([]string, 0, len(m))
+	for k := range m {
 		if k == "data" || k == "schema" {
 			continue
 		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	indent := len(prefix) / 2
+	for _, k := range keys {
+		v := m[k]
 		switch v.(type) {
 		case map[string]interface{}, []interface{}:
 			fmt.Fprintf(w, "%s%s:\n", prefix, Sanitize(k))

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -283,3 +283,184 @@ func TestFormatNames(t *testing.T) {
 		t.Errorf("FormatNames() returned %d names, want 4", len(names))
 	}
 }
+
+func TestRenderCAResultTable_MultiRow(t *testing.T) {
+	value := map[string]interface{}{
+		"question": "top events",
+		"results": map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{"event_type": "LLM_RESPONSE", "count": float64(54)},
+				map[string]interface{}{"event_type": "LLM_REQUEST", "count": float64(52)},
+			},
+			"schema": map[string]interface{}{
+				"fields": []interface{}{
+					map[string]interface{}{"name": "event_type", "type": "STRING"},
+					map[string]interface{}{"name": "count", "type": "INTEGER"},
+				},
+			},
+			"name": "top_events",
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := Render(Text, value); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if !strings.Contains(out, "event_type") || !strings.Contains(out, "count") {
+		t.Errorf("missing table headers in: %s", out)
+	}
+	if !strings.Contains(out, "LLM_RESPONSE") || !strings.Contains(out, "54") {
+		t.Errorf("missing row data in: %s", out)
+	}
+	if !strings.Contains(out, "(2 rows)") {
+		t.Errorf("missing row count in: %s", out)
+	}
+	if !strings.Contains(out, "name: top_events") {
+		t.Errorf("missing metadata 'name' in: %s", out)
+	}
+}
+
+func TestRenderCAResultTable_SingleRow(t *testing.T) {
+	value := map[string]interface{}{
+		"results": map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{"total": float64(318)},
+			},
+			"schema": map[string]interface{}{
+				"fields": []interface{}{
+					map[string]interface{}{"name": "total", "type": "INTEGER"},
+				},
+			},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := Render(Text, value); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if !strings.Contains(out, "total") {
+		t.Errorf("missing header in: %s", out)
+	}
+	if !strings.Contains(out, "318") {
+		t.Errorf("missing value in: %s", out)
+	}
+	if !strings.Contains(out, "(1 rows)") {
+		t.Errorf("missing row count in: %s", out)
+	}
+}
+
+func TestRenderCAResultTable_ZeroRows(t *testing.T) {
+	value := map[string]interface{}{
+		"results": map[string]interface{}{
+			"data": []interface{}{},
+			"schema": map[string]interface{}{
+				"fields": []interface{}{
+					map[string]interface{}{"name": "x", "type": "STRING"},
+				},
+			},
+			"name": "empty_result",
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := Render(Text, value); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if !strings.Contains(out, "(0 rows)") {
+		t.Errorf("missing (0 rows) in: %s", out)
+	}
+	if !strings.Contains(out, "name: empty_result") {
+		t.Errorf("missing metadata in: %s", out)
+	}
+}
+
+func TestRenderCAResultTable_NullAndMissingFields(t *testing.T) {
+	value := map[string]interface{}{
+		"results": map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{"a": "hello", "b": nil},
+				map[string]interface{}{"a": "world"}, // "b" missing
+			},
+			"schema": map[string]interface{}{
+				"fields": []interface{}{
+					map[string]interface{}{"name": "a", "type": "STRING"},
+					map[string]interface{}{"name": "b", "type": "STRING"},
+				},
+			},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := Render(Text, value); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if strings.Count(out, "NULL") != 2 {
+		t.Errorf("expected 2 NULLs (nil + missing), got: %s", out)
+	}
+}
+
+func TestRenderCAResultTable_EscapesNewlines(t *testing.T) {
+	value := map[string]interface{}{
+		"results": map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{"msg": "line1\nline2\ttab"},
+			},
+			"schema": map[string]interface{}{
+				"fields": []interface{}{
+					map[string]interface{}{"name": "msg", "type": "STRING"},
+				},
+			},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := Render(Text, value); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if !strings.Contains(out, `line1\nline2\ttab`) {
+		t.Errorf("newline/tab not escaped in: %s", out)
+	}
+}
+
+func TestRenderCAResultTable_NestedMetadata(t *testing.T) {
+	value := map[string]interface{}{
+		"results": map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{"x": float64(1)},
+			},
+			"schema": map[string]interface{}{
+				"fields": []interface{}{
+					map[string]interface{}{"name": "x", "type": "INTEGER"},
+				},
+			},
+			"name": "test",
+			"metadata": map[string]interface{}{
+				"nested_key": "nested_value",
+			},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := Render(Text, value); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// Nested metadata should NOT show as map[...]
+	if strings.Contains(out, "map[") {
+		t.Errorf("nested metadata rendered as raw map: %s", out)
+	}
+	if !strings.Contains(out, "nested_key: nested_value") {
+		t.Errorf("missing nested metadata in: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary

Fix: CA responses with tabular data (`results.data` + `results.schema.fields`) now render as aligned tables instead of generic key-value pairs.

## Before

```
results:
  data:
    event_count: 54
    event_type: LLM_RESPONSE
    ---
    event_count: 52
    event_type: LLM_REQUEST
  name: top_event_types
  schema:
    fields:
      mode: NULLABLE
      name: event_type
      type: STRING
      ---
      ...
```

## After

```
results:
  event_type            | event_count
  ----------------------+-----------
  LLM_RESPONSE          | 54
  LLM_REQUEST           | 52
  AGENT_COMPLETED       | 35
  INVOCATION_STARTING   | 34
  USER_MESSAGE_RECEIVED | 33
  (5 rows)
  name: top_event_types
```

## How it works

Detects the CA result shape in `renderTextValue`: a map with `data` (array of flat row objects) + `schema.fields` (column definitions). Renders the data as a psql-style table inline, then prints remaining metadata (name, etc.) below.

Does NOT trigger for:
- BQ query responses (those use `rows[].f[].v` format, handled by `isBQQueryResult`)
- Objects without both `data` array AND `schema.fields`
- Objects where `data[0]` is not a map

## Test plan

- [x] `gofmt`, `go build`, `go vet`, `go test ./... -count=1` pass
- [x] Multi-row CA result renders as table (top 5 event types)
- [x] Single-row CA result renders as table (total rows)
- [x] BQ jobs query still uses its own renderer (unchanged)
- [x] Non-CA objects with schema field not affected (#7 fix still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)