### PR TITLE
MCP Phase 0.5: shared allowlist, exclude cli, deterministic args

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -209,41 +209,13 @@ func (s *Server) handleToolsCall(req JSONRPCRequest) {
 		return
 	}
 
-	// Build positional flag set from contract metadata.
-	positionalFlags := make(map[string]bool)
-	for _, f := range contract.Flags {
-		if f.Positional {
-			positionalFlags[f.Name] = true
-		}
+	// Validate required positional args before subprocess.
+	if err := s.validateRequiredPositionals(contract, params.Arguments); err != nil {
+		s.writeError(req.ID, -32602, "Invalid params", err.Error())
+		return
 	}
 
-	// Convert tool name back to command args.
-	cmdArgs := toolNameToArgs(params.Name)
-
-	// Build subprocess args with deterministic ordering.
-	args := append(cmdArgs, "--format", s.Format)
-
-	// Sort argument keys for deterministic subprocess invocation.
-	keys := make([]string, 0, len(params.Arguments))
-	for k := range params.Arguments {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	var positionalArgs []string
-	for _, k := range keys {
-		v := params.Arguments[k]
-		sv := fmt.Sprintf("%v", v)
-		if sv == "" {
-			continue
-		}
-		if positionalFlags[k] {
-			positionalArgs = append(positionalArgs, sv)
-		} else {
-			args = append(args, "--"+k, sv)
-		}
-	}
-	args = append(args, positionalArgs...)
+	args := s.buildArgs(contract, params.Name, params.Arguments)
 
 	// Execute subprocess.
 	cmd := exec.Command(s.DcxBinary, args...)
@@ -286,6 +258,67 @@ func (s *Server) writeError(id interface{}, code int, message, data string) {
 	}
 	respData, _ := json.Marshal(resp)
 	fmt.Fprintln(os.Stdout, string(respData))
+}
+
+// validateRequiredPositionals checks that required positional args are present.
+func (s *Server) validateRequiredPositionals(contract *contracts.CommandContract, args map[string]interface{}) error {
+	for _, f := range contract.Flags {
+		if f.Positional && f.Required {
+			if _, ok := args[f.Name]; !ok {
+				return fmt.Errorf("required positional argument %q is missing", f.Name)
+			}
+		}
+	}
+	return nil
+}
+
+// buildArgs constructs deterministic subprocess args from a contract and arguments.
+// Non-positional flags are sorted by key. Positional args follow in contract order.
+func (s *Server) buildArgs(contract *contracts.CommandContract, toolName string, arguments map[string]interface{}) []string {
+	cmdArgs := toolNameToArgs(toolName)
+	args := append(cmdArgs, "--format", s.Format)
+
+	// Identify positional flags.
+	positionalFlags := make(map[string]bool)
+	for _, f := range contract.Flags {
+		if f.Positional {
+			positionalFlags[f.Name] = true
+		}
+	}
+
+	// Sorted non-positional flags.
+	var flagKeys []string
+	for k := range arguments {
+		if !positionalFlags[k] {
+			flagKeys = append(flagKeys, k)
+		}
+	}
+	sort.Strings(flagKeys)
+
+	for _, k := range flagKeys {
+		sv := fmt.Sprintf("%v", arguments[k])
+		if sv == "" {
+			continue
+		}
+		args = append(args, "--"+k, sv)
+	}
+
+	// Positional args in contract declaration order.
+	for _, f := range contract.Flags {
+		if !f.Positional {
+			continue
+		}
+		v, ok := arguments[f.Name]
+		if !ok {
+			continue
+		}
+		sv := fmt.Sprintf("%v", v)
+		if sv != "" {
+			args = append(args, sv)
+		}
+	}
+
+	return args
 }
 
 // commandToToolName converts "dcx datasets list" to "dcx_datasets_list".

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -154,10 +154,13 @@ var blockedDomains = map[string]bool{
 // Returns the canonical contract or an error. Used by tools/list, tools/call,
 // and future progressive/batch modes.
 func (s *Server) CanExecuteMCPCommand(command string) (*contracts.CommandContract, error) {
-	// Normalize: trim, strip "dcx " prefix, rejoin.
-	cmd := strings.TrimSpace(command)
-	cmd = strings.TrimPrefix(cmd, "dcx ")
-	cmd = "dcx " + strings.Join(strings.Fields(cmd), " ")
+	// Normalize: tokenize first (splits on all whitespace including tabs),
+	// strip leading "dcx" token if present, rejoin with single spaces.
+	tokens := strings.Fields(command)
+	if len(tokens) > 0 && tokens[0] == "dcx" {
+		tokens = tokens[1:]
+	}
+	cmd := "dcx " + strings.Join(tokens, " ")
 
 	contract, ok := s.Registry.Get(cmd)
 	if !ok {
@@ -260,12 +263,17 @@ func (s *Server) writeError(id interface{}, code int, message, data string) {
 	fmt.Fprintln(os.Stdout, string(respData))
 }
 
-// validateRequiredPositionals checks that required positional args are present.
+// validateRequiredPositionals checks that required positional args are present
+// and non-empty (rejects nil, "", and whitespace-only values).
 func (s *Server) validateRequiredPositionals(contract *contracts.CommandContract, args map[string]interface{}) error {
 	for _, f := range contract.Flags {
 		if f.Positional && f.Required {
-			if _, ok := args[f.Name]; !ok {
+			v, ok := args[f.Name]
+			if !ok || v == nil {
 				return fmt.Errorf("required positional argument %q is missing", f.Name)
+			}
+			if sv := strings.TrimSpace(fmt.Sprintf("%v", v)); sv == "" {
+				return fmt.Errorf("required positional argument %q is empty", f.Name)
 			}
 		}
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 
 	"github.com/haiyuan-eng-google/dcx-cli/internal/contracts"
@@ -144,24 +145,44 @@ func (s *Server) handleInitialize(req JSONRPCRequest) {
 	s.writeResult(req.ID, result)
 }
 
+// blockedDomains are domains excluded from MCP — not useful as agent tools.
+var blockedDomains = map[string]bool{
+	"meta": true, "auth": true, "profiles": true, "mcp": true, "cli": true,
+}
+
+// CanExecuteMCPCommand validates that a command is allowed via MCP.
+// Returns the canonical contract or an error. Used by tools/list, tools/call,
+// and future progressive/batch modes.
+func (s *Server) CanExecuteMCPCommand(command string) (*contracts.CommandContract, error) {
+	// Normalize: trim, strip "dcx " prefix, rejoin.
+	cmd := strings.TrimSpace(command)
+	cmd = strings.TrimPrefix(cmd, "dcx ")
+	cmd = "dcx " + strings.Join(strings.Fields(cmd), " ")
+
+	contract, ok := s.Registry.Get(cmd)
+	if !ok {
+		return nil, fmt.Errorf("unknown command: %s", command)
+	}
+	if blockedDomains[contract.Domain] {
+		return nil, fmt.Errorf("command not available via MCP: %s", command)
+	}
+	if contract.IsMutation {
+		return nil, fmt.Errorf("MCP bridge is read-only; mutation commands are not available")
+	}
+	if strings.HasSuffix(contract.Command, " wait") {
+		return nil, fmt.Errorf("long-polling commands are not available via MCP")
+	}
+	return contract, nil
+}
+
 func (s *Server) handleToolsList(req JSONRPCRequest) {
 	all := s.Registry.All()
 	var tools []MCPTool
 
 	for _, c := range all {
-		// Skip non-data commands — not useful as MCP tools.
-		if c.Domain == "meta" || c.Domain == "auth" || c.Domain == "profiles" || c.Domain == "mcp" {
+		if _, err := s.CanExecuteMCPCommand(c.Command); err != nil {
 			continue
 		}
-		// Only expose read-only, non-blocking commands.
-		if c.IsMutation {
-			continue
-		}
-		// Exclude long-polling commands (not suitable for tool calls).
-		if strings.HasSuffix(c.Command, " wait") {
-			continue
-		}
-
 		tool := MCPTool{
 			Name:        commandToToolName(c.Command),
 			Description: c.Description,
@@ -180,30 +201,43 @@ func (s *Server) handleToolsCall(req JSONRPCRequest) {
 		return
 	}
 
-	// Block mutations and long-polling commands.
+	// Resolve and validate the command via shared helper.
 	cmdName := toolNameToCommand(params.Name)
-	if contract, ok := s.Registry.Get(cmdName); ok && contract.IsMutation {
-		s.writeError(req.ID, -32601, "Method not allowed", "MCP bridge is read-only; mutation commands are not available")
+	contract, err := s.CanExecuteMCPCommand(cmdName)
+	if err != nil {
+		s.writeError(req.ID, -32601, "Method not allowed", err.Error())
 		return
 	}
-	if strings.HasSuffix(cmdName, " wait") {
-		s.writeError(req.ID, -32601, "Method not allowed", "Long-polling commands are not available via MCP")
-		return
+
+	// Build positional flag set from contract metadata.
+	positionalFlags := make(map[string]bool)
+	for _, f := range contract.Flags {
+		if f.Positional {
+			positionalFlags[f.Name] = true
+		}
 	}
 
 	// Convert tool name back to command args.
 	cmdArgs := toolNameToArgs(params.Name)
 
-	// Build subprocess args, stringifying non-string values.
-	// "question" is a positional arg for ca ask — append it without a flag prefix.
+	// Build subprocess args with deterministic ordering.
 	args := append(cmdArgs, "--format", s.Format)
+
+	// Sort argument keys for deterministic subprocess invocation.
+	keys := make([]string, 0, len(params.Arguments))
+	for k := range params.Arguments {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
 	var positionalArgs []string
-	for k, v := range params.Arguments {
+	for _, k := range keys {
+		v := params.Arguments[k]
 		sv := fmt.Sprintf("%v", v)
 		if sv == "" {
 			continue
 		}
-		if k == "question" {
+		if positionalFlags[k] {
 			positionalArgs = append(positionalArgs, sv)
 		} else {
 			args = append(args, "--"+k, sv)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,184 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/haiyuan-eng-google/dcx-cli/internal/contracts"
+)
+
+func testRegistry() *contracts.Registry {
+	r := contracts.NewRegistry()
+	r.Register(contracts.BuildContract("datasets list", "bigquery", "List datasets", nil, false, false))
+	r.Register(contracts.BuildContract("datasets delete", "bigquery", "Delete a dataset", nil, true, false))
+	r.Register(contracts.BuildContract("spanner databases get-ddl", "spanner", "Get DDL", nil, false, false))
+	r.Register(contracts.BuildContract("spanner operations wait", "spanner", "Wait for operation", nil, false, false))
+	r.Register(contracts.BuildContract("auth check", "auth", "Check auth", nil, false, false))
+	r.Register(contracts.BuildContract("meta commands", "meta", "List commands", nil, false, false))
+	r.Register(contracts.BuildContract("completion", "cli", "Shell completion", nil, false, false))
+	r.Register(contracts.BuildContract("mcp serve", "mcp", "MCP server", nil, false, false))
+	r.Register(contracts.BuildContract("profiles list", "profiles", "List profiles", nil, false, false))
+
+	// CA ask with positional question arg.
+	caFlags := []contracts.FlagContract{
+		{Name: "question", Type: "string", Description: "Question", Required: true, Positional: true},
+		{Name: "agent", Type: "string", Description: "Agent"},
+		{Name: "tables", Type: "string", Description: "Tables"},
+	}
+	r.Register(contracts.BuildContract("ca ask", "ca", "Ask a question", caFlags, false, false))
+
+	return r
+}
+
+func TestCanExecuteMCPCommand_AllowsReadOnly(t *testing.T) {
+	s := NewServer(testRegistry(), "json-minified", "dcx")
+
+	tests := []struct {
+		input string
+	}{
+		{"datasets list"},
+		{"dcx datasets list"},
+		{"  datasets   list  "},
+		{"spanner databases get-ddl"},
+		{"ca ask"},
+	}
+	for _, tt := range tests {
+		c, err := s.CanExecuteMCPCommand(tt.input)
+		if err != nil {
+			t.Errorf("CanExecuteMCPCommand(%q) = error %v, want allowed", tt.input, err)
+		}
+		if c == nil {
+			t.Errorf("CanExecuteMCPCommand(%q) returned nil contract", tt.input)
+		}
+	}
+}
+
+func TestCanExecuteMCPCommand_RejectsBlocked(t *testing.T) {
+	s := NewServer(testRegistry(), "json-minified", "dcx")
+
+	tests := []struct {
+		input   string
+		wantMsg string
+	}{
+		{"nonexistent", "unknown command"},
+		{"datasets delete", "read-only"},
+		{"spanner operations wait", "long-polling"},
+		{"auth check", "not available via MCP"},
+		{"meta commands", "not available via MCP"},
+		{"completion", "not available via MCP"},
+		{"mcp serve", "not available via MCP"},
+		{"profiles list", "not available via MCP"},
+	}
+	for _, tt := range tests {
+		_, err := s.CanExecuteMCPCommand(tt.input)
+		if err == nil {
+			t.Errorf("CanExecuteMCPCommand(%q) = nil error, want rejection", tt.input)
+			continue
+		}
+		if !contains(err.Error(), tt.wantMsg) {
+			t.Errorf("CanExecuteMCPCommand(%q) error = %q, want to contain %q", tt.input, err.Error(), tt.wantMsg)
+		}
+	}
+}
+
+func TestCanExecuteMCPCommand_NormalizesWhitespace(t *testing.T) {
+	s := NewServer(testRegistry(), "json-minified", "dcx")
+
+	// All should resolve to the same contract.
+	variants := []string{
+		"datasets list",
+		"dcx datasets list",
+		"  datasets   list  ",
+		"dcx  datasets  list",
+	}
+	for _, v := range variants {
+		c, err := s.CanExecuteMCPCommand(v)
+		if err != nil {
+			t.Errorf("CanExecuteMCPCommand(%q) = error %v", v, err)
+			continue
+		}
+		if c.Command != "dcx datasets list" {
+			t.Errorf("CanExecuteMCPCommand(%q) resolved to %q, want %q", v, c.Command, "dcx datasets list")
+		}
+	}
+}
+
+func TestBuildToolCallArgs_DeterministicOrder(t *testing.T) {
+	s := NewServer(testRegistry(), "json-minified", "dcx")
+	contract, _ := s.CanExecuteMCPCommand("datasets list")
+
+	args := map[string]interface{}{
+		"project-id": "P",
+		"location":   "US",
+		"dataset-id": "D",
+	}
+
+	// Run multiple times to verify determinism.
+	for i := 0; i < 10; i++ {
+		result := s.buildArgs(contract, "dcx_datasets_list", args)
+		// Flags should be in sorted order after the command segments and --format.
+		// Expected: ["datasets", "list", "--format", "json-minified", "--dataset-id", "D", "--location", "US", "--project-id", "P"]
+		expected := []string{"datasets", "list", "--format", "json-minified", "--dataset-id", "D", "--location", "US", "--project-id", "P"}
+		if len(result) != len(expected) {
+			t.Fatalf("buildArgs attempt %d: got %v, want %v", i, result, expected)
+		}
+		for j := range expected {
+			if result[j] != expected[j] {
+				t.Fatalf("buildArgs attempt %d: position %d got %q, want %q\nfull: %v", i, j, result[j], expected[j], result)
+			}
+		}
+	}
+}
+
+func TestBuildToolCallArgs_PositionalInContractOrder(t *testing.T) {
+	s := NewServer(testRegistry(), "json-minified", "dcx")
+	contract, _ := s.CanExecuteMCPCommand("ca ask")
+
+	args := map[string]interface{}{
+		"question": "how many rows?",
+		"agent":    "my-agent",
+		"tables":   "p.d.t",
+	}
+
+	result := s.buildArgs(contract, "dcx_ca_ask", args)
+	// Flags sorted, then positional at end.
+	// Expected: ["ca", "ask", "--format", "json-minified", "--agent", "my-agent", "--tables", "p.d.t", "how many rows?"]
+	last := result[len(result)-1]
+	if last != "how many rows?" {
+		t.Errorf("positional arg should be last, got %q at end\nfull: %v", last, result)
+	}
+	// "question" should NOT appear as "--question"
+	for _, a := range result {
+		if a == "--question" {
+			t.Errorf("positional arg 'question' should not be a flag\nfull: %v", result)
+		}
+	}
+}
+
+func TestBuildToolCallArgs_MissingRequiredPositional(t *testing.T) {
+	s := NewServer(testRegistry(), "json-minified", "dcx")
+	contract, _ := s.CanExecuteMCPCommand("ca ask")
+
+	// Missing "question" which is required + positional.
+	args := map[string]interface{}{
+		"agent":  "my-agent",
+		"tables": "p.d.t",
+	}
+
+	err := s.validateRequiredPositionals(contract, args)
+	if err == nil {
+		t.Error("expected error for missing required positional, got nil")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -26,6 +26,14 @@ func testRegistry() *contracts.Registry {
 	}
 	r.Register(contracts.BuildContract("ca ask", "ca", "Ask a question", caFlags, false, false))
 
+	// Fake command with two positionals to test ordering.
+	twoPositionalFlags := []contracts.FlagContract{
+		{Name: "source", Type: "string", Description: "Source", Required: true, Positional: true},
+		{Name: "destination", Type: "string", Description: "Destination", Required: true, Positional: true},
+		{Name: "verbose", Type: "bool", Description: "Verbose"},
+	}
+	r.Register(contracts.BuildContract("data copy", "bigquery", "Copy data", twoPositionalFlags, false, false))
+
 	return r
 }
 
@@ -151,6 +159,71 @@ func TestBuildToolCallArgs_PositionalInContractOrder(t *testing.T) {
 		if a == "--question" {
 			t.Errorf("positional arg 'question' should not be a flag\nfull: %v", result)
 		}
+	}
+}
+
+func TestBuildToolCallArgs_TwoPositionalsInContractOrder(t *testing.T) {
+	s := NewServer(testRegistry(), "json-minified", "dcx")
+	contract, _ := s.CanExecuteMCPCommand("data copy")
+
+	args := map[string]interface{}{
+		"destination": "dest_table",   // listed second in contract
+		"source":      "source_table", // listed first in contract
+		"verbose":     "true",
+	}
+
+	result := s.buildArgs(contract, "dcx_data_copy", args)
+	// Positionals must be in contract order: source first, destination second.
+	// Flags before positionals.
+	n := len(result)
+	if n < 2 {
+		t.Fatalf("expected at least 2 positional args, got %v", result)
+	}
+	if result[n-2] != "source_table" {
+		t.Errorf("first positional should be 'source_table', got %q\nfull: %v", result[n-2], result)
+	}
+	if result[n-1] != "dest_table" {
+		t.Errorf("second positional should be 'dest_table', got %q\nfull: %v", result[n-1], result)
+	}
+	// --verbose should be before positionals
+	for _, a := range result {
+		if a == "--source" || a == "--destination" {
+			t.Errorf("positional args should not appear as flags\nfull: %v", result)
+		}
+	}
+}
+
+func TestValidateRequiredPositionals_EmptyValues(t *testing.T) {
+	s := NewServer(testRegistry(), "json-minified", "dcx")
+	contract, _ := s.CanExecuteMCPCommand("ca ask")
+
+	tests := []struct {
+		name string
+		args map[string]interface{}
+	}{
+		{"missing key", map[string]interface{}{"agent": "a"}},
+		{"nil value", map[string]interface{}{"question": nil, "agent": "a"}},
+		{"empty string", map[string]interface{}{"question": "", "agent": "a"}},
+		{"whitespace only", map[string]interface{}{"question": "   ", "agent": "a"}},
+	}
+	for _, tt := range tests {
+		err := s.validateRequiredPositionals(contract, tt.args)
+		if err == nil {
+			t.Errorf("%s: expected error, got nil", tt.name)
+		}
+	}
+}
+
+func TestCanExecuteMCPCommand_TabWhitespace(t *testing.T) {
+	s := NewServer(testRegistry(), "json-minified", "dcx")
+
+	// Tab-separated should normalize correctly.
+	c, err := s.CanExecuteMCPCommand("dcx\tdatasets\tlist")
+	if err != nil {
+		t.Errorf("tab-separated command failed: %v", err)
+	}
+	if c != nil && c.Command != "dcx datasets list" {
+		t.Errorf("resolved to %q, want %q", c.Command, "dcx datasets list")
 	}
 }
 


### PR DESCRIPTION
## Summary

Cleanup and hardening of `dcx mcp serve` before progressive discovery mode (issue #60 Phase 1). Introduces the shared validation helper that will be reused by progressive `dcx_execute` and batch modes.

### Changes

| # | Change | Impact |
|---|--------|--------|
| 1 | `CanExecuteMCPCommand` shared helper | Single validation path for tools/list, tools/call, future modes |
| 2 | Exclude `cli` domain | 57 → 56 tools (`dcx_completion` removed) |
| 3 | Unknown commands rejected before subprocess | Proper JSON-RPC error instead of CLI error in tool result |
| 4 | Deterministic argument ordering | Sorted keys → reproducible subprocess args |
| 5 | Positional args from contract metadata | Uses `Positional` field, not hardcoded `"question"` |

### Verified edge cases

```
dcx_does_not_exist → {"error": "unknown command: dcx does not exist"}
dcx_completion     → {"error": "command not available via MCP: dcx completion"}
dcx_datasets_delete → {"error": "MCP bridge is read-only; mutation commands are not available"}
dcx_datasets_list  → works (real BQ data returned)
```

### Updated baseline

| Metric | Before | After |
|---|---|---|
| Tool count | 57 | 56 |
| Payload bytes | 59,108 | 58,468 |
| `dcx_completion` exposed | Yes | No |
| Unknown command handling | Subprocess error | JSON-RPC error |
| Arg ordering | Nondeterministic | Sorted |

### Command normalization

`CanExecuteMCPCommand` handles:
- `"datasets list"` → resolves
- `"dcx datasets list"` → resolves
- `"  datasets   list  "` → resolves (whitespace normalized)
- Unknown → rejected before subprocess

## Test plan

- [x] `go build`, `go vet`, `go test ./... -count=1` pass
- [x] tools/list returns 56 tools (no completion)
- [x] Unknown command → JSON-RPC error (not subprocess error)
- [x] `dcx_completion` call → blocked
- [x] Mutation call → blocked
- [x] `dcx_datasets_list` → real data returned

Partial #60 (Phase 0.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)