### PR TITLE
MCP Phase 2: batch composition with $prev references

### DIFF
--- a/internal/jsonpath/resolve.go
+++ b/internal/jsonpath/resolve.go
@@ -59,7 +59,7 @@ func Resolve(data interface{}, path string) (string, error) {
 			}
 			value = arr[index]
 		} else {
-			break
+			return "", fmt.Errorf("invalid path segment near %q", path)
 		}
 	}
 

--- a/internal/jsonpath/resolve.go
+++ b/internal/jsonpath/resolve.go
@@ -1,0 +1,101 @@
+// Package jsonpath provides a small JSON path resolver for dcx.
+//
+// Supports field access (.field) and array indexing ([N]).
+// Used by REPL $last references and MCP batch $prev references.
+package jsonpath
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Resolve evaluates a path expression against JSON data.
+// Path syntax: .field, [N], chained (e.g., ".items[0]._resource_id").
+// Returns the resolved value as a string.
+func Resolve(data interface{}, path string) (string, error) {
+	value := data
+
+	for len(path) > 0 {
+		if path[0] == '.' {
+			path = path[1:]
+			end := strings.IndexAny(path, ".[")
+			if end < 0 {
+				end = len(path)
+			}
+			fieldName := path[:end]
+			path = path[end:]
+
+			m, ok := value.(map[string]interface{})
+			if !ok {
+				return "", fmt.Errorf("cannot access .%s on non-object", fieldName)
+			}
+			value, ok = m[fieldName]
+			if !ok {
+				return "", fmt.Errorf("field %q not found", fieldName)
+			}
+		} else if path[0] == '[' {
+			end := strings.Index(path, "]")
+			if end < 0 {
+				return "", fmt.Errorf("unclosed bracket in path")
+			}
+			indexStr := path[1:end]
+			path = path[end+1:]
+
+			arr, ok := value.([]interface{})
+			if !ok {
+				return "", fmt.Errorf("cannot index non-array")
+			}
+			if !isDigitsOnly(indexStr) {
+				return "", fmt.Errorf("invalid index [%s]", indexStr)
+			}
+			index, err := strconv.Atoi(indexStr)
+			if err != nil {
+				return "", fmt.Errorf("invalid index [%s]", indexStr)
+			}
+			if index >= len(arr) {
+				return "", fmt.Errorf("index [%d] out of range (length %d)", index, len(arr))
+			}
+			value = arr[index]
+		} else {
+			break
+		}
+	}
+
+	return FormatValue(value), nil
+}
+
+// FormatValue converts a JSON value to a string.
+func FormatValue(v interface{}) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case json.Number:
+		return val.String()
+	case float64:
+		if val == float64(int64(val)) {
+			return fmt.Sprintf("%d", int64(val))
+		}
+		return fmt.Sprintf("%g", val)
+	case bool:
+		return fmt.Sprintf("%t", val)
+	case nil:
+		return ""
+	default:
+		data, _ := json.Marshal(val)
+		return string(data)
+	}
+}
+
+func isDigitsOnly(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, ch := range s {
+		if ch < '0' || ch > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/jsonpath/resolve_test.go
+++ b/internal/jsonpath/resolve_test.go
@@ -1,0 +1,145 @@
+package jsonpath
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func parseJSON(s string) interface{} {
+	var v interface{}
+	dec := json.NewDecoder(strings.NewReader(s))
+	dec.UseNumber()
+	dec.Decode(&v)
+	return v
+}
+
+func TestResolve_FieldAccess(t *testing.T) {
+	data := parseJSON(`{"name":"alice","age":30}`)
+	got, err := Resolve(data, ".name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "alice" {
+		t.Errorf("got %q, want %q", got, "alice")
+	}
+}
+
+func TestResolve_ArrayIndex(t *testing.T) {
+	data := parseJSON(`[{"id":"a"},{"id":"b"}]`)
+	got, err := Resolve(data, "[1].id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "b" {
+		t.Errorf("got %q, want %q", got, "b")
+	}
+}
+
+func TestResolve_NestedPath(t *testing.T) {
+	data := parseJSON(`{"items":[{"_resource_id":"analytics"},{"_resource_id":"logs"}]}`)
+	got, err := Resolve(data, ".items[0]._resource_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "analytics" {
+		t.Errorf("got %q, want %q", got, "analytics")
+	}
+}
+
+func TestResolve_EmptyPath(t *testing.T) {
+	data := parseJSON(`{"x":1}`)
+	got, err := Resolve(data, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == "" {
+		t.Error("empty path should return formatted value")
+	}
+}
+
+func TestResolve_FieldNotFound(t *testing.T) {
+	data := parseJSON(`{"name":"alice"}`)
+	_, err := Resolve(data, ".nonexistent")
+	if err == nil {
+		t.Error("expected error for missing field")
+	}
+}
+
+func TestResolve_IndexOutOfRange(t *testing.T) {
+	data := parseJSON(`[1,2,3]`)
+	_, err := Resolve(data, "[99]")
+	if err == nil {
+		t.Error("expected error for out-of-range index")
+	}
+}
+
+func TestResolve_InvalidIndex(t *testing.T) {
+	data := parseJSON(`[1,2]`)
+	tests := []string{"[abc]", "[-1]", "[+0]", "[0:1]"}
+	for _, path := range tests {
+		_, err := Resolve(data, path)
+		if err == nil {
+			t.Errorf("expected error for index %q", path)
+		}
+	}
+}
+
+func TestResolve_TrailingJunk(t *testing.T) {
+	data := parseJSON(`{"items":[{"name":"x"}]}`)
+	tests := []string{
+		".items[0]garbage",
+		".items[0].name[0]tail",
+		".itemsXYZ",
+	}
+	for _, path := range tests {
+		_, err := Resolve(data, path)
+		if err == nil {
+			t.Errorf("expected error for trailing junk in path %q", path)
+		}
+	}
+}
+
+func TestResolve_AccessFieldOnNonObject(t *testing.T) {
+	data := parseJSON(`"just a string"`)
+	_, err := Resolve(data, ".field")
+	if err == nil {
+		t.Error("expected error for field access on non-object")
+	}
+}
+
+func TestResolve_IndexNonArray(t *testing.T) {
+	data := parseJSON(`{"x":1}`)
+	_, err := Resolve(data, "[0]")
+	if err == nil {
+		t.Error("expected error for index on non-array")
+	}
+}
+
+func TestResolve_UnclosedBracket(t *testing.T) {
+	data := parseJSON(`[1,2]`)
+	_, err := Resolve(data, "[0")
+	if err == nil {
+		t.Error("expected error for unclosed bracket")
+	}
+}
+
+func TestFormatValue_Types(t *testing.T) {
+	tests := []struct {
+		input interface{}
+		want  string
+	}{
+		{"hello", "hello"},
+		{json.Number("42"), "42"},
+		{float64(3.14), "3.14"},
+		{float64(100), "100"},
+		{true, "true"},
+		{nil, ""},
+	}
+	for _, tt := range tests {
+		got := FormatValue(tt.input)
+		if got != tt.want {
+			t.Errorf("FormatValue(%v) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -9,6 +9,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"sort"
@@ -639,11 +640,15 @@ func (s *Server) handleBatch(req JSONRPCRequest, params ToolCallParams) {
 			sv, ok := v.(string)
 			if ok && strings.Contains(sv, "$prev") {
 				if prevJSON == nil {
+					msg := "$prev referenced but no previous result"
+					if i > 0 {
+						msg = "$prev referenced but previous step did not produce valid JSON"
+					}
 					results = append(results, batchStepResult{
 						Step:     i,
 						Command:  step.Command,
 						ExitCode: 1,
-						Error:    fmt.Sprintf("$prev referenced but no previous result (step %d)", i),
+						Error:    fmt.Sprintf("step %d: %s", i, msg),
 					})
 					goto done // fail-fast
 				}
@@ -702,13 +707,19 @@ func (s *Server) handleBatch(req JSONRPCRequest, params ToolCallParams) {
 				goto done
 			}
 
-			// Parse JSON for $prev.
+			// Parse JSON for $prev. Enforce EOF to reject trailing
+			// content (matches $last EOF enforcement in REPL).
 			var parsed interface{}
 			trimmed := strings.TrimSpace(string(output))
 			if len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') {
 				dec := json.NewDecoder(strings.NewReader(trimmed))
 				dec.UseNumber()
-				if dec.Decode(&parsed) != nil {
+				if dec.Decode(&parsed) == nil {
+					var extra json.RawMessage
+					if dec.Decode(&extra) != io.EOF {
+						parsed = nil // trailing content — not clean JSON
+					}
+				} else {
 					parsed = nil
 				}
 			}
@@ -730,10 +741,11 @@ func (s *Server) handleBatch(req JSONRPCRequest, params ToolCallParams) {
 				goto done
 			}
 
-			// Update $prev for next step.
-			if parsed != nil {
-				prevJSON = parsed
-			}
+			// Update $prev for next step. Always update so $prev
+			// reflects the immediate previous step, not a stale earlier one.
+			// If the step produced no JSON, $prev becomes nil and later
+			// $prev references will fail with "did not produce JSON".
+			prevJSON = parsed
 		}
 	}
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/haiyuan-eng-google/dcx-cli/internal/contracts"
+	"github.com/haiyuan-eng-google/dcx-cli/internal/jsonpath"
 )
 
 // AllowedMCPFormats are the formats allowed for MCP output.
@@ -276,6 +277,34 @@ func (s *Server) handleToolsListProgressive(req JSONRPCRequest) {
 				"required": []string{"command"},
 			},
 		},
+		{
+			Name:        "dcx_batch",
+			Description: "Execute multiple read-only dcx commands in sequence. Use $prev.path to reference the previous step's JSON result.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"steps": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"command": map[string]interface{}{
+									"type":        "string",
+									"description": "Command path, e.g. 'datasets list'",
+								},
+								"args": map[string]interface{}{
+									"type":        "object",
+									"description": "Arguments. Use $prev.path to reference previous step result.",
+								},
+							},
+							"required": []string{"command"},
+						},
+						"description": "Ordered list of commands (max 10)",
+					},
+				},
+				"required": []string{"steps"},
+			},
+		},
 	}
 
 	s.writeResult(req.ID, ToolsListResult{Tools: tools})
@@ -300,9 +329,12 @@ func (s *Server) handleToolsCall(req JSONRPCRequest) {
 		case "dcx_execute":
 			s.handleExecute(req, params)
 			return
+		case "dcx_batch":
+			s.handleBatch(req, params)
+			return
 		}
 		s.writeError(req.ID, -32601, "Method not found",
-			fmt.Sprintf("unknown tool %q; available: dcx_discover, dcx_describe, dcx_execute", params.Name))
+			fmt.Sprintf("unknown tool %q; available: dcx_discover, dcx_describe, dcx_execute, dcx_batch", params.Name))
 		return
 	}
 
@@ -504,6 +536,237 @@ func (s *Server) executeAndRespond(id interface{}, args []string) {
 	s.writeResult(id, ToolCallResult{
 		Content: []ToolContent{{Type: "text", Text: string(output)}},
 	})
+}
+
+// maxBatchSteps is the maximum number of steps in a batch.
+const maxBatchSteps = 10
+
+// maxBatchOutputBytes is the maximum total output bytes across all steps.
+const maxBatchOutputBytes = 1024 * 1024 // 1 MB
+
+// batchStep is a single step in a batch request.
+type batchStep struct {
+	Command string                 `json:"command"`
+	Args    map[string]interface{} `json:"args"`
+}
+
+// batchStepResult is the result of a single batch step.
+type batchStepResult struct {
+	Step     int         `json:"step"`
+	Command  string      `json:"command"`
+	ExitCode int         `json:"exit_code"`
+	Output   string      `json:"output"`
+	JSON     interface{} `json:"json,omitempty"`
+	Error    string      `json:"error,omitempty"`
+}
+
+// handleBatch executes multiple commands in sequence with $prev references.
+func (s *Server) handleBatch(req JSONRPCRequest, params ToolCallParams) {
+	stepsRaw, ok := params.Arguments["steps"]
+	if !ok || stepsRaw == nil {
+		s.writeError(req.ID, -32602, "Invalid params", "required argument \"steps\" is missing")
+		return
+	}
+	stepsArr, ok := stepsRaw.([]interface{})
+	if !ok {
+		s.writeError(req.ID, -32602, "Invalid params",
+			fmt.Sprintf("\"steps\" must be an array, got %T", stepsRaw))
+		return
+	}
+	if len(stepsArr) == 0 {
+		s.writeError(req.ID, -32602, "Invalid params", "\"steps\" must not be empty")
+		return
+	}
+	if len(stepsArr) > maxBatchSteps {
+		s.writeError(req.ID, -32602, "Invalid params",
+			fmt.Sprintf("\"steps\" has %d entries, max is %d", len(stepsArr), maxBatchSteps))
+		return
+	}
+
+	// Parse steps.
+	var steps []batchStep
+	for i, raw := range stepsArr {
+		m, ok := raw.(map[string]interface{})
+		if !ok {
+			s.writeError(req.ID, -32602, "Invalid params",
+				fmt.Sprintf("step %d must be an object", i))
+			return
+		}
+		command, _ := m["command"].(string)
+		if command == "" {
+			s.writeError(req.ID, -32602, "Invalid params",
+				fmt.Sprintf("step %d: required field \"command\" is missing", i))
+			return
+		}
+		args := make(map[string]interface{})
+		if argsRaw, ok := m["args"]; ok {
+			if argsRaw == nil {
+				s.writeError(req.ID, -32602, "Invalid params",
+					fmt.Sprintf("step %d: \"args\" must be an object, got null", i))
+				return
+			}
+			argsMap, ok := argsRaw.(map[string]interface{})
+			if !ok {
+				s.writeError(req.ID, -32602, "Invalid params",
+					fmt.Sprintf("step %d: \"args\" must be an object, got %T", i, argsRaw))
+				return
+			}
+			args = argsMap
+		}
+		steps = append(steps, batchStep{Command: command, Args: args})
+	}
+
+	// Validate all steps upfront (fail-fast before any execution).
+	for i, step := range steps {
+		if _, err := s.CanExecuteMCPCommand(step.Command); err != nil {
+			s.writeError(req.ID, -32601, "Method not allowed",
+				fmt.Sprintf("step %d (%s): %s", i, step.Command, err.Error()))
+			return
+		}
+	}
+
+	// Execute steps sequentially.
+	var results []batchStepResult
+	var prevJSON interface{}
+	totalBytes := 0
+
+	for i, step := range steps {
+		contract, _ := s.CanExecuteMCPCommand(step.Command)
+
+		// Resolve $prev references in args.
+		resolvedArgs := make(map[string]interface{})
+		for k, v := range step.Args {
+			sv, ok := v.(string)
+			if ok && strings.Contains(sv, "$prev") {
+				if prevJSON == nil {
+					results = append(results, batchStepResult{
+						Step:     i,
+						Command:  step.Command,
+						ExitCode: 1,
+						Error:    fmt.Sprintf("$prev referenced but no previous result (step %d)", i),
+					})
+					goto done // fail-fast
+				}
+				resolved, err := resolvePrevRef(sv, prevJSON)
+				if err != nil {
+					results = append(results, batchStepResult{
+						Step:     i,
+						Command:  step.Command,
+						ExitCode: 1,
+						Error:    fmt.Sprintf("step %d: %s", i, err.Error()),
+					})
+					goto done
+				}
+				resolvedArgs[k] = resolved
+			} else {
+				resolvedArgs[k] = v
+			}
+		}
+
+		// Validate positionals.
+		if err := s.validateRequiredPositionals(contract, resolvedArgs); err != nil {
+			results = append(results, batchStepResult{
+				Step:     i,
+				Command:  step.Command,
+				ExitCode: 1,
+				Error:    fmt.Sprintf("step %d: %s", i, err.Error()),
+			})
+			goto done
+		}
+
+		// Build and execute.
+		{
+			toolName := commandToToolName(contract.Command)
+			args := s.buildArgs(contract, toolName, resolvedArgs)
+
+			cmd := exec.Command(s.DcxBinary, args...)
+			output, err := cmd.CombinedOutput()
+
+			exitCode := 0
+			if err != nil {
+				if exitErr, ok := err.(*exec.ExitError); ok {
+					exitCode = exitErr.ExitCode()
+				} else {
+					exitCode = 1
+				}
+			}
+
+			totalBytes += len(output)
+			if totalBytes > maxBatchOutputBytes {
+				results = append(results, batchStepResult{
+					Step:     i,
+					Command:  step.Command,
+					ExitCode: 1,
+					Error:    fmt.Sprintf("step %d: total output exceeds %d bytes limit", i, maxBatchOutputBytes),
+				})
+				goto done
+			}
+
+			// Parse JSON for $prev.
+			var parsed interface{}
+			trimmed := strings.TrimSpace(string(output))
+			if len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') {
+				dec := json.NewDecoder(strings.NewReader(trimmed))
+				dec.UseNumber()
+				if dec.Decode(&parsed) != nil {
+					parsed = nil
+				}
+			}
+
+			result := batchStepResult{
+				Step:     i,
+				Command:  step.Command,
+				ExitCode: exitCode,
+				Output:   string(output),
+				JSON:     parsed,
+			}
+			if exitCode != 0 {
+				result.Error = fmt.Sprintf("command exited with code %d", exitCode)
+			}
+			results = append(results, result)
+
+			// Fail-fast on error.
+			if exitCode != 0 {
+				goto done
+			}
+
+			// Update $prev for next step.
+			if parsed != nil {
+				prevJSON = parsed
+			}
+		}
+	}
+
+done:
+	data, _ := json.Marshal(results)
+	s.writeResult(req.ID, ToolCallResult{
+		Content: []ToolContent{{Type: "text", Text: string(data)}},
+	})
+}
+
+// resolvePrevRef expands $prev references in a string value.
+func resolvePrevRef(value string, prevJSON interface{}) (string, error) {
+	idx := strings.Index(value, "$prev")
+	if idx < 0 {
+		return value, nil
+	}
+
+	prefix := value[:idx]
+	path := value[idx+5:] // after "$prev"
+	suffix := ""
+
+	// If path is empty, return the whole prev as JSON.
+	if path == "" || (path[0] != '.' && path[0] != '[') {
+		suffix = path
+		resolved := jsonpath.FormatValue(prevJSON)
+		return prefix + resolved + suffix, nil
+	}
+
+	resolved, err := jsonpath.Resolve(prevJSON, path)
+	if err != nil {
+		return "", fmt.Errorf("$prev%s: %w", path, err)
+	}
+	return prefix + resolved, nil
 }
 
 func (s *Server) writeResult(id interface{}, result interface{}) {


### PR DESCRIPTION
## Summary

Adds `dcx_batch` tool to progressive MCP mode, enabling multi-step command chains in a single LLM turn with `$prev` result references.

## Usage

```json
{"name": "dcx_batch", "arguments": {
  "steps": [
    {"command": "datasets list", "args": {"project-id": "P", "output-fields": "_resource_id"}},
    {"command": "tables list", "args": {"project-id": "P", "dataset-id": "$prev.items[4]._resource_id"}}
  ]
}}
```

Returns per-step results in one response — agent gets both datasets and tables in one tool call instead of two.

## Features

- **$prev references**: `$prev.items[0]._resource_id` resolves against previous step's JSON output
- **Fail-fast**: stops on first error, returns partial results
- **Upfront validation**: all steps checked via `CanExecuteMCPCommand` before any execution
- **Limits**: max 10 steps, max 1MB total output
- **Per-step envelope**: `{step, command, exit_code, output, json, error}`

## Shared jsonpath package

Extracted the path resolver from REPL's `$last` evaluator into `internal/jsonpath`:
- `.field` access and `[N]` array indexing
- Used by both MCP batch (`$prev`) and REPL (`$last`)
- Unit-testable independently

## Edge cases verified

| Test | Result |
|------|--------|
| 2-step chain with $prev | Datasets → tables via `$prev.items[4]._resource_id` |
| Mutation in any step | Rejected upfront before execution |
| Empty steps | `-32602` |
| steps: null | `-32602` |
| $prev with no prior result | Error identifies step index |
| $prev out of range | Error with path detail |
| Step 1 API error | Fail-fast, step 2 not executed |

## Test plan

- [x] `gofmt`, `go build`, `go vet`, `go test ./... -count=1` pass
- [x] 2-step batch with $prev returns real BQ data
- [x] Mutation rejected upfront
- [x] $prev without prior result gives clear error
- [x] Fail-fast stops on first error
- [x] Classic mode unchanged
- [x] Progressive tools/list now shows 4 tools (discover, describe, execute, batch)

Implements #60 Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)