### PR TITLE
MCP Phase 4: deterministic result compaction

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1006,14 +1006,17 @@ func (s *Server) handleBatch(req JSONRPCRequest, params ToolCallParams) {
 				}
 			}
 
-			// Apply result_mode compaction if JSON is available.
+			// Apply result_mode compaction for the response envelope.
+			// Keep raw parsed JSON for $prev resolution so chained steps
+			// can access the full data (e.g., $prev.items[4] after a
+			// compact step that only sampled 3 items).
 			outputStr := string(output)
-			var resultJSON interface{} = parsed
+			var envelopeJSON interface{} = parsed
 			if parsed != nil && step.ResultMode != "full" {
 				compacted := compactResult(parsed, step.ResultMode)
 				compactedData, _ := json.Marshal(compacted)
 				outputStr = string(compactedData)
-				resultJSON = compacted
+				envelopeJSON = compacted
 			}
 
 			result := batchStepResult{
@@ -1021,7 +1024,7 @@ func (s *Server) handleBatch(req JSONRPCRequest, params ToolCallParams) {
 				Command:  step.Command,
 				ExitCode: exitCode,
 				Output:   outputStr,
-				JSON:     resultJSON,
+				JSON:     envelopeJSON,
 			}
 			if exitCode != 0 {
 				result.Error = fmt.Sprintf("command exited with code %d", exitCode)
@@ -1033,10 +1036,8 @@ func (s *Server) handleBatch(req JSONRPCRequest, params ToolCallParams) {
 				goto done
 			}
 
-			// Update $prev for next step. Always update so $prev
-			// reflects the immediate previous step, not a stale earlier one.
-			// If the step produced no JSON, $prev becomes nil and later
-			// $prev references will fail with "did not produce JSON".
+			// Update $prev with RAW parsed JSON (not compacted) so
+			// the next step can resolve full paths like $prev.items[4].
 			prevJSON = parsed
 		}
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -279,6 +279,11 @@ func (s *Server) handleToolsListProgressive(req JSONRPCRequest) {
 						"type":        "object",
 						"description": "Command arguments as key-value pairs",
 					},
+					"result_mode": map[string]interface{}{
+						"type":        "string",
+						"description": "Result shaping: full (default), compact (count+sample+schema), count_only, schema_only",
+						"enum":        []string{"full", "compact", "count_only", "schema_only"},
+					},
 				},
 				"required": []string{"command"},
 			},
@@ -520,10 +525,16 @@ func (s *Server) handleExecute(req JSONRPCRequest, params ToolCallParams) {
 		return
 	}
 
+	// Extract result_mode (default: "full").
+	resultMode, _ := params.Arguments["result_mode"].(string)
+	if resultMode == "" {
+		resultMode = "full"
+	}
+
 	// Build the tool name from the canonical command for buildArgs.
 	toolName := commandToToolName(contract.Command)
 	args := s.buildArgs(contract, toolName, cmdArgs)
-	s.executeAndRespond(req.ID, args)
+	s.executeWithCompaction(req.ID, args, resultMode)
 }
 
 // executeAndRespond runs a subprocess and writes the result.
@@ -542,6 +553,229 @@ func (s *Server) executeAndRespond(id interface{}, args []string) {
 	s.writeResult(id, ToolCallResult{
 		Content: []ToolContent{{Type: "text", Text: string(output)}},
 	})
+}
+
+// validResultModes are the accepted result_mode values.
+var validResultModes = map[string]bool{
+	"full": true, "compact": true, "count_only": true, "schema_only": true,
+}
+
+// executeWithCompaction runs a subprocess and optionally compacts the result.
+func (s *Server) executeWithCompaction(id interface{}, args []string, resultMode string) {
+	if !validResultModes[resultMode] {
+		s.writeError(id, -32602, "Invalid params",
+			fmt.Sprintf("invalid result_mode %q; valid: full, compact, count_only, schema_only", resultMode))
+		return
+	}
+
+	cmd := exec.Command(s.DcxBinary, args...)
+	output, err := cmd.CombinedOutput()
+
+	if err != nil {
+		s.writeResult(id, ToolCallResult{
+			Content: []ToolContent{{Type: "text", Text: string(output)}},
+			IsError: true,
+		})
+		return
+	}
+
+	if resultMode == "full" {
+		s.writeResult(id, ToolCallResult{
+			Content: []ToolContent{{Type: "text", Text: string(output)}},
+		})
+		return
+	}
+
+	// Parse JSON for compaction.
+	var parsed interface{}
+	trimmed := strings.TrimSpace(string(output))
+	dec := json.NewDecoder(strings.NewReader(trimmed))
+	dec.UseNumber()
+	if dec.Decode(&parsed) != nil {
+		// Can't parse — return raw output.
+		s.writeResult(id, ToolCallResult{
+			Content: []ToolContent{{Type: "text", Text: string(output)}},
+		})
+		return
+	}
+
+	compacted := compactResult(parsed, resultMode)
+	data, _ := json.Marshal(compacted)
+	s.writeResult(id, ToolCallResult{
+		Content: []ToolContent{{Type: "text", Text: string(data)}},
+	})
+}
+
+// compactResult reshapes a JSON result based on the mode.
+func compactResult(data interface{}, mode string) interface{} {
+	m, isMap := data.(map[string]interface{})
+
+	switch mode {
+	case "compact":
+		return compactMode(data, m, isMap)
+	case "count_only":
+		return countOnlyMode(data, m, isMap)
+	case "schema_only":
+		return schemaOnlyMode(data, m, isMap)
+	default:
+		return data
+	}
+}
+
+// compactMode returns count + sample (first 3) + field names for list envelopes,
+// or top-level keys for single objects.
+func compactMode(data interface{}, m map[string]interface{}, isMap bool) interface{} {
+	if !isMap {
+		return data
+	}
+
+	// List envelope: {items: [...], source: "..."}
+	if itemsRaw, ok := m["items"]; ok {
+		if items, ok := itemsRaw.([]interface{}); ok {
+			result := map[string]interface{}{
+				"count": len(items),
+			}
+
+			// Sample: first 3 items.
+			sampleSize := 3
+			if len(items) < sampleSize {
+				sampleSize = len(items)
+			}
+			if sampleSize > 0 {
+				result["sample"] = items[:sampleSize]
+			}
+
+			// Field names from first item.
+			if len(items) > 0 {
+				if first, ok := items[0].(map[string]interface{}); ok {
+					fields := make([]string, 0, len(first))
+					for k := range first {
+						fields = append(fields, k)
+					}
+					sort.Strings(fields)
+					result["fields"] = fields
+				}
+			}
+
+			// Preserve envelope metadata.
+			for k, v := range m {
+				if k == "items" {
+					continue
+				}
+				result[k] = v
+			}
+			return result
+		}
+	}
+
+	// Single object: return top-level keys.
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return map[string]interface{}{
+		"type": "object",
+		"keys": keys,
+	}
+}
+
+// countOnlyMode returns just the item count for list envelopes.
+func countOnlyMode(data interface{}, m map[string]interface{}, isMap bool) interface{} {
+	if !isMap {
+		return map[string]interface{}{"count": 1}
+	}
+	if itemsRaw, ok := m["items"]; ok {
+		if items, ok := itemsRaw.([]interface{}); ok {
+			result := map[string]interface{}{"count": len(items)}
+			// Preserve source and next_page_token.
+			if v, ok := m["source"]; ok {
+				result["source"] = v
+			}
+			if v, ok := m["next_page_token"]; ok {
+				result["next_page_token"] = v
+			}
+			return result
+		}
+	}
+	return map[string]interface{}{"count": 1}
+}
+
+// schemaOnlyMode returns field names and types from the first item.
+func schemaOnlyMode(data interface{}, m map[string]interface{}, isMap bool) interface{} {
+	if !isMap {
+		return map[string]interface{}{"type": fmt.Sprintf("%T", data)}
+	}
+
+	// List envelope: extract from first item.
+	if itemsRaw, ok := m["items"]; ok {
+		if items, ok := itemsRaw.([]interface{}); ok {
+			if len(items) > 0 {
+				if first, ok := items[0].(map[string]interface{}); ok {
+					fields := make([]map[string]string, 0, len(first))
+					keys := make([]string, 0, len(first))
+					for k := range first {
+						keys = append(keys, k)
+					}
+					sort.Strings(keys)
+					for _, k := range keys {
+						v := first[k]
+						fields = append(fields, map[string]string{
+							"name": k,
+							"type": jsonTypeOf(v),
+						})
+					}
+					return map[string]interface{}{
+						"item_count": len(items),
+						"fields":     fields,
+					}
+				}
+			}
+			return map[string]interface{}{
+				"item_count": 0,
+				"fields":     []interface{}{},
+			}
+		}
+	}
+
+	// Single object: return key→type map.
+	fields := make([]map[string]string, 0, len(m))
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fields = append(fields, map[string]string{
+			"name": k,
+			"type": jsonTypeOf(m[k]),
+		})
+	}
+	return map[string]interface{}{
+		"type":   "object",
+		"fields": fields,
+	}
+}
+
+func jsonTypeOf(v interface{}) string {
+	switch v.(type) {
+	case string:
+		return "string"
+	case json.Number:
+		return "number"
+	case float64:
+		return "number"
+	case bool:
+		return "boolean"
+	case nil:
+		return "null"
+	case map[string]interface{}:
+		return "object"
+	case []interface{}:
+		return "array"
+	default:
+		return "unknown"
+	}
 }
 
 // maxBatchSteps is the maximum number of steps in a batch.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -307,6 +307,11 @@ func (s *Server) handleToolsListProgressive(req JSONRPCRequest) {
 									"type":        "object",
 									"description": "Arguments. Use $prev.path to reference previous step result.",
 								},
+								"result_mode": map[string]interface{}{
+									"type":        "string",
+									"description": "Result shaping per step: full (default), compact, count_only, schema_only",
+									"enum":        []string{"full", "compact", "count_only", "schema_only"},
+								},
 							},
 							"required": []string{"command"},
 						},
@@ -525,10 +530,22 @@ func (s *Server) handleExecute(req JSONRPCRequest, params ToolCallParams) {
 		return
 	}
 
-	// Extract result_mode (default: "full").
-	resultMode, _ := params.Arguments["result_mode"].(string)
-	if resultMode == "" {
-		resultMode = "full"
+	// Extract result_mode (default: "full"). Reject non-string.
+	resultMode := "full"
+	if rmRaw, ok := params.Arguments["result_mode"]; ok {
+		if rmRaw == nil {
+			s.writeError(req.ID, -32602, "Invalid params", "\"result_mode\" must be a string, got null")
+			return
+		}
+		rmStr, isStr := rmRaw.(string)
+		if !isStr {
+			s.writeError(req.ID, -32602, "Invalid params",
+				fmt.Sprintf("\"result_mode\" must be a string, got %T", rmRaw))
+			return
+		}
+		if rmStr != "" {
+			resultMode = rmStr
+		}
 	}
 
 	// Build the tool name from the canonical command for buildArgs.
@@ -586,13 +603,21 @@ func (s *Server) executeWithCompaction(id interface{}, args []string, resultMode
 		return
 	}
 
-	// Parse JSON for compaction.
+	// Parse JSON for compaction. Enforce EOF to reject trailing content.
 	var parsed interface{}
 	trimmed := strings.TrimSpace(string(output))
 	dec := json.NewDecoder(strings.NewReader(trimmed))
 	dec.UseNumber()
 	if dec.Decode(&parsed) != nil {
 		// Can't parse — return raw output.
+		s.writeResult(id, ToolCallResult{
+			Content: []ToolContent{{Type: "text", Text: string(output)}},
+		})
+		return
+	}
+	var extra json.RawMessage
+	if dec.Decode(&extra) != io.EOF {
+		// Trailing content — not clean JSON, return raw.
 		s.writeResult(id, ToolCallResult{
 			Content: []ToolContent{{Type: "text", Text: string(output)}},
 		})
@@ -786,8 +811,9 @@ const maxBatchOutputBytes = 1024 * 1024 // 1 MB
 
 // batchStep is a single step in a batch request.
 type batchStep struct {
-	Command string                 `json:"command"`
-	Args    map[string]interface{} `json:"args"`
+	Command    string                 `json:"command"`
+	Args       map[string]interface{} `json:"args"`
+	ResultMode string                 `json:"result_mode"`
 }
 
 // batchStepResult is the result of a single batch step.
@@ -853,7 +879,24 @@ func (s *Server) handleBatch(req JSONRPCRequest, params ToolCallParams) {
 			}
 			args = argsMap
 		}
-		steps = append(steps, batchStep{Command: command, Args: args})
+		rm := "full"
+		if rmRaw, ok := m["result_mode"]; ok && rmRaw != nil {
+			rmStr, isStr := rmRaw.(string)
+			if !isStr {
+				s.writeError(req.ID, -32602, "Invalid params",
+					fmt.Sprintf("step %d: \"result_mode\" must be a string, got %T", i, rmRaw))
+				return
+			}
+			if rmStr != "" && !validResultModes[rmStr] {
+				s.writeError(req.ID, -32602, "Invalid params",
+					fmt.Sprintf("step %d: invalid result_mode %q; valid: full, compact, count_only, schema_only", i, rmStr))
+				return
+			}
+			if rmStr != "" {
+				rm = rmStr
+			}
+		}
+		steps = append(steps, batchStep{Command: command, Args: args, ResultMode: rm})
 	}
 
 	// Validate all steps upfront (fail-fast before any execution).
@@ -963,12 +1006,22 @@ func (s *Server) handleBatch(req JSONRPCRequest, params ToolCallParams) {
 				}
 			}
 
+			// Apply result_mode compaction if JSON is available.
+			outputStr := string(output)
+			var resultJSON interface{} = parsed
+			if parsed != nil && step.ResultMode != "full" {
+				compacted := compactResult(parsed, step.ResultMode)
+				compactedData, _ := json.Marshal(compacted)
+				outputStr = string(compactedData)
+				resultJSON = compacted
+			}
+
 			result := batchStepResult{
 				Step:     i,
 				Command:  step.Command,
 				ExitCode: exitCode,
-				Output:   string(output),
-				JSON:     parsed,
+				Output:   outputStr,
+				JSON:     resultJSON,
 			}
 			if exitCode != 0 {
 				result.Error = fmt.Sprintf("command exited with code %d", exitCode)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -473,6 +474,134 @@ func TestResourceRead_CommandURIPathConversion(t *testing.T) {
 		if back != tt.command {
 			t.Errorf("path %q → command %q, want %q", tt.path, back, tt.command)
 		}
+	}
+}
+
+// Result compaction tests.
+
+func TestCompactResult_ListEnvelope(t *testing.T) {
+	data := map[string]interface{}{
+		"items": []interface{}{
+			map[string]interface{}{"_resource_id": "a", "location": "US"},
+			map[string]interface{}{"_resource_id": "b", "location": "EU"},
+			map[string]interface{}{"_resource_id": "c", "location": "US"},
+			map[string]interface{}{"_resource_id": "d", "location": "EU"},
+		},
+		"source": "BigQuery",
+	}
+
+	result := compactResult(data, "compact")
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("compact result should be a map, got %T", result)
+	}
+	if m["count"] != 4 {
+		t.Errorf("count = %v, want 4", m["count"])
+	}
+	sample, ok := m["sample"].([]interface{})
+	if !ok || len(sample) != 3 {
+		t.Errorf("sample should have 3 items, got %v", m["sample"])
+	}
+	if m["source"] != "BigQuery" {
+		t.Errorf("source should be preserved, got %v", m["source"])
+	}
+}
+
+func TestCompactResult_CountOnly(t *testing.T) {
+	data := map[string]interface{}{
+		"items":  []interface{}{1, 2, 3, 4, 5},
+		"source": "test",
+	}
+
+	result := compactResult(data, "count_only")
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("count_only result should be a map, got %T", result)
+	}
+	if m["count"] != 5 {
+		t.Errorf("count = %v, want 5", m["count"])
+	}
+	if m["source"] != "test" {
+		t.Errorf("source should be preserved")
+	}
+	if _, has := m["items"]; has {
+		t.Error("count_only should not include items")
+	}
+}
+
+func TestCompactResult_SchemaOnly(t *testing.T) {
+	data := map[string]interface{}{
+		"items": []interface{}{
+			map[string]interface{}{"name": "alice", "age": json.Number("30"), "active": true},
+		},
+	}
+
+	result := compactResult(data, "schema_only")
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("schema_only result should be a map, got %T", result)
+	}
+	fields, ok := m["fields"].([]map[string]string)
+	if !ok {
+		t.Fatalf("fields should be []map[string]string, got %T", m["fields"])
+	}
+	if len(fields) != 3 {
+		t.Errorf("expected 3 fields, got %d", len(fields))
+	}
+	// Fields should be sorted.
+	if fields[0]["name"] != "active" || fields[1]["name"] != "age" || fields[2]["name"] != "name" {
+		t.Errorf("fields not sorted: %v", fields)
+	}
+}
+
+func TestCompactResult_EmptyList(t *testing.T) {
+	data := map[string]interface{}{
+		"items":  []interface{}{},
+		"source": "test",
+	}
+
+	compact := compactResult(data, "compact")
+	m := compact.(map[string]interface{})
+	if m["count"] != 0 {
+		t.Errorf("compact empty list: count = %v, want 0", m["count"])
+	}
+
+	countOnly := compactResult(data, "count_only")
+	m2 := countOnly.(map[string]interface{})
+	if m2["count"] != 0 {
+		t.Errorf("count_only empty list: count = %v, want 0", m2["count"])
+	}
+
+	schemaOnly := compactResult(data, "schema_only")
+	m3 := schemaOnly.(map[string]interface{})
+	if m3["item_count"] != 0 {
+		t.Errorf("schema_only empty list: item_count = %v, want 0", m3["item_count"])
+	}
+}
+
+func TestCompactResult_SingleObject(t *testing.T) {
+	data := map[string]interface{}{
+		"name":   "test",
+		"status": "ok",
+	}
+
+	compact := compactResult(data, "compact")
+	m := compact.(map[string]interface{})
+	keys, ok := m["keys"].([]string)
+	if !ok {
+		t.Fatalf("compact single object should return keys, got %T", m["keys"])
+	}
+	if len(keys) != 2 {
+		t.Errorf("expected 2 keys, got %d", len(keys))
+	}
+}
+
+func TestCompactResult_FullPassthrough(t *testing.T) {
+	data := map[string]interface{}{"x": 1}
+	result := compactResult(data, "full")
+	m, ok := result.(map[string]interface{})
+	if !ok || m["x"] != 1 {
+		t.Error("full mode should return data unchanged")
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `result_mode` parameter to `dcx_execute` in progressive mode for controlling result payload size. All modes are deterministic — no LLM summarization.

## Modes

| Mode | What it returns | Use case |
|------|----------------|----------|
| `full` (default) | Raw command output | Data retrieval |
| `compact` | count + sample (3 items) + field names | Exploration |
| `count_only` | Item count + source | Size check before fetching |
| `schema_only` | Field names and types | Shape discovery |

## Usage

```json
{"name": "dcx_execute", "arguments": {
  "command": "datasets list",
  "args": {"project-id": "P"},
  "result_mode": "compact"
}}
```

## Measured results (datasets list, 37 items)

| Mode | Bytes | Reduction |
|------|-------|-----------|
| full | 10,036 | baseline |
| compact | 1,082 | **89%** |
| schema_only | 368 | **96%** |
| count_only | 112 | **99%** |

## Example outputs

**compact:**
```json
{"count":37,"fields":["_resource_id"],"sample":[{"_resource_id":"adk_e2e_test"},{"_resource_id":"adk_logs"},{"_resource_id":"adk_logs_US"}],"source":"BigQuery"}
```

**count_only:**
```json
{"count":37,"source":"BigQuery"}
```

**schema_only:**
```json
{"fields":[{"name":"_resource_id","type":"string"},{"name":"datasetReference","type":"object"},{"name":"id","type":"string"},{"name":"kind","type":"string"},{"name":"location","type":"string"},{"name":"type","type":"string"}],"item_count":37}
```

## Agent workflow

```
1. dcx_execute "datasets list" result_mode=count_only  → "37 items"
2. dcx_execute "datasets list" result_mode=schema_only  → "fields: _resource_id, location, ..."
3. dcx_execute "datasets list" result_mode=compact       → first 3 items + count
4. dcx_execute "datasets get" args={dataset-id: "analytics"}  → full detail for one
```

## Design

- Compaction happens after subprocess execution (parse JSON, reshape)
- Non-JSON output returns raw (compaction not applicable)
- Invalid result_mode returns `-32602`
- Classic mode unchanged (always full)
- Single objects: compact returns top-level keys; schema_only returns key→type map

## Test plan

- [x] `gofmt`, `go build`, `go vet`, `go test ./... -count=1` pass
- [x] `full` returns raw output (unchanged)
- [x] `compact` returns count + 3 samples + field names
- [x] `count_only` returns count + source
- [x] `schema_only` returns field names and types
- [x] Invalid mode returns `-32602`
- [x] Classic mode unaffected

Completes #60 (all 4 phases shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)