### PR TITLE
Update README: MCP progressive mode and result compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,15 +236,15 @@ Two modes:
 # Classic: all 56 tools upfront (~58 KB)
 dcx mcp serve
 
-# Progressive: 5 meta-tools (~1.5 KB, 98% smaller)
+# Progressive: 4 meta-tools (~1.8 KB, 97% smaller)
 dcx mcp serve --mode=progressive
 ```
 
 Progressive mode tools:
 - `dcx_discover` — list commands by domain
 - `dcx_describe` — load one command's schema on demand
-- `dcx_execute` — run a command (with optional `result_mode`: compact/count_only/schema_only)
-- `dcx_batch` — multi-step chains with `$prev` references
+- `dcx_execute` — run a command (with optional `result_mode`: full/compact/count_only/schema_only)
+- `dcx_batch` — multi-step chains with `$prev` references and per-step `result_mode`
 
 Both modes expose 63 navigable resources via `resources/list` + `resources/read`
 (`dcx://index`, `dcx://domains/<domain>`, `dcx://commands/<path>`).

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Features: tab completion, `$last` result references, `/output-fields` toggle,
 | **Auth** | `auth status`, `auth check`, `auth login`, `auth logout` |
 | **Profiles** | `profiles list`, `profiles validate`, `profiles test` |
 | **Introspection** | `meta commands`, `meta describe`, `meta generate-skills`, `meta schema` |
-| **MCP** | `mcp serve` (JSON-RPC 2.0 / stdio, read-only, default `json-minified`) |
+| **MCP** | `mcp serve` (JSON-RPC 2.0 / stdio, read-only, classic + progressive modes) |
 | **Skills** | `dcx-bigquery`, `dcx-databases`, `dcx-looker`, `dcx-ca` (checked-in) |
 
 Run `dcx meta commands` for the full machine-readable list.
@@ -229,6 +229,25 @@ schemas, and skill generation.
 `dcx mcp serve` exposes read-only commands as MCP tools over stdio
 (JSON-RPC 2.0). Output defaults to `json-minified`; override with
 `DCX_MCP_FORMAT=json`.
+
+Two modes:
+
+```bash
+# Classic: all 56 tools upfront (~58 KB)
+dcx mcp serve
+
+# Progressive: 5 meta-tools (~1.5 KB, 98% smaller)
+dcx mcp serve --mode=progressive
+```
+
+Progressive mode tools:
+- `dcx_discover` — list commands by domain
+- `dcx_describe` — load one command's schema on demand
+- `dcx_execute` — run a command (with optional `result_mode`: compact/count_only/schema_only)
+- `dcx_batch` — multi-step chains with `$prev` references
+
+Both modes expose 63 navigable resources via `resources/list` + `resources/read`
+(`dcx://index`, `dcx://domains/<domain>`, `dcx://commands/<path>`).
 
 ### Profiles
 


### PR DESCRIPTION
## Summary

Updates README to document MCP progressive mode (Phases 0.5-4, PRs #61-#65).

### Changes

- MCP Bridge section: documents classic vs progressive modes
- Progressive tools listed: discover, describe, execute, batch
- Result compaction modes: compact, count_only, schema_only
- Resources: 63 navigable resources via resources/list + read
- Commands table: updated to mention both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)