### PR TITLE
Add --select as alias for --output-fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Features: tab completion, `$last` result references, `/output-fields` toggle,
 | **Auth** | `auth status`, `auth check`, `auth login`, `auth logout` |
 | **Profiles** | `profiles list`, `profiles validate`, `profiles test` |
 | **Introspection** | `meta commands`, `meta describe`, `meta generate-skills`, `meta schema` |
-| **MCP** | `mcp serve` (JSON-RPC 2.0 / stdio, read-only, classic + progressive modes) |
+| **MCP** | `mcp serve` (JSON-RPC 2.0 / stdio, read-only, default `json-minified`) |
 | **Skills** | `dcx-bigquery`, `dcx-databases`, `dcx-looker`, `dcx-ca` (checked-in) |
 
 Run `dcx meta commands` for the full machine-readable list.
@@ -229,25 +229,6 @@ schemas, and skill generation.
 `dcx mcp serve` exposes read-only commands as MCP tools over stdio
 (JSON-RPC 2.0). Output defaults to `json-minified`; override with
 `DCX_MCP_FORMAT=json`.
-
-Two modes:
-
-```bash
-# Classic: all 56 tools upfront (~58 KB)
-dcx mcp serve
-
-# Progressive: 4 meta-tools (~1.8 KB, 97% smaller)
-dcx mcp serve --mode=progressive
-```
-
-Progressive mode tools:
-- `dcx_discover` — list commands by domain
-- `dcx_describe` — load one command's schema on demand
-- `dcx_execute` — run a command (with optional `result_mode`: full/compact/count_only/schema_only)
-- `dcx_batch` — multi-step chains with `$prev` references and per-step `result_mode`
-
-Both modes expose 63 navigable resources via `resources/list` + `resources/read`
-(`dcx://index`, `dcx://domains/<domain>`, `dcx://commands/<path>`).
 
 ### Profiles
 

--- a/README.md
+++ b/README.md
@@ -236,15 +236,15 @@ Two modes:
 # Classic: all 56 tools upfront (~58 KB)
 dcx mcp serve
 
-# Progressive: 5 meta-tools (~1.5 KB, 98% smaller)
+# Progressive: 4 meta-tools (~1.8 KB, 97% smaller)
 dcx mcp serve --mode=progressive
 ```
 
 Progressive mode tools:
 - `dcx_discover` — list commands by domain
 - `dcx_describe` — load one command's schema on demand
-- `dcx_execute` — run a command (with optional `result_mode`: compact/count_only/schema_only)
-- `dcx_batch` — multi-step chains with `$prev` references
+- `dcx_execute` — run a command (with optional `result_mode`: full/compact/count_only/schema_only)
+- `dcx_batch` — multi-step chains with `$prev` references and per-step `result_mode`
 
 Both modes expose 63 navigable resources via `resources/list` + `resources/read`
 (`dcx://index`, `dcx://domains/<domain>`, `dcx://commands/<path>`).

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Features: tab completion, `$last` result references, `/output-fields` toggle,
 | **Auth** | `auth status`, `auth check`, `auth login`, `auth logout` |
 | **Profiles** | `profiles list`, `profiles validate`, `profiles test` |
 | **Introspection** | `meta commands`, `meta describe`, `meta generate-skills`, `meta schema` |
-| **MCP** | `mcp serve` (JSON-RPC 2.0 / stdio, read-only, default `json-minified`) |
+| **MCP** | `mcp serve` (JSON-RPC 2.0 / stdio, read-only, classic + progressive modes) |
 | **Skills** | `dcx-bigquery`, `dcx-databases`, `dcx-looker`, `dcx-ca` (checked-in) |
 
 Run `dcx meta commands` for the full machine-readable list.
@@ -229,6 +229,25 @@ schemas, and skill generation.
 `dcx mcp serve` exposes read-only commands as MCP tools over stdio
 (JSON-RPC 2.0). Output defaults to `json-minified`; override with
 `DCX_MCP_FORMAT=json`.
+
+Two modes:
+
+```bash
+# Classic: all 56 tools upfront (~58 KB)
+dcx mcp serve
+
+# Progressive: 5 meta-tools (~1.5 KB, 98% smaller)
+dcx mcp serve --mode=progressive
+```
+
+Progressive mode tools:
+- `dcx_discover` — list commands by domain
+- `dcx_describe` — load one command's schema on demand
+- `dcx_execute` — run a command (with optional `result_mode`: compact/count_only/schema_only)
+- `dcx_batch` — multi-step chains with `$prev` references
+
+Both modes expose 63 navigable resources via `resources/list` + `resources/read`
+(`dcx://index`, `dcx://domains/<domain>`, `dcx://commands/<path>`).
 
 ### Profiles
 

--- a/internal/cli/repl.go
+++ b/internal/cli/repl.go
@@ -284,8 +284,13 @@ func handleBuiltin(input string, ctx *replContext) bool {
 		return true
 	}
 
-	if strings.HasPrefix(lower, "/output-fields") {
-		rest := strings.TrimSpace(input[len("/output-fields"):])
+	if strings.HasPrefix(lower, "/output-fields") || strings.HasPrefix(lower, "/select") {
+		var rest string
+		if strings.HasPrefix(lower, "/output-fields") {
+			rest = strings.TrimSpace(input[len("/output-fields"):])
+		} else {
+			rest = strings.TrimSpace(input[len("/select"):])
+		}
 		if rest == "" || rest == "clear" {
 			ctx.OutputFields = ""
 			fmt.Fprintln(os.Stderr, "  output-fields: (all)")
@@ -922,6 +927,7 @@ func buildCompleter(registry *contracts.Registry) func(line string, pos int) (st
 		"show context", "clear context",
 		"/format json", "/format text", "/format table",
 		"/output-fields", "/output-fields clear",
+		"/select", "/select clear",
 		"help", "exit", "quit",
 	}
 

--- a/internal/cli/repl.go
+++ b/internal/cli/repl.go
@@ -284,7 +284,7 @@ func handleBuiltin(input string, ctx *replContext) bool {
 		return true
 	}
 
-	if strings.HasPrefix(lower, "/output-fields") || strings.HasPrefix(lower, "/select") {
+	if strings.HasPrefix(lower, "/output-fields") || lower == "/select" || strings.HasPrefix(lower, "/select ") {
 		var rest string
 		if strings.HasPrefix(lower, "/output-fields") {
 			rest = strings.TrimSpace(input[len("/output-fields"):])

--- a/internal/cli/repl.go
+++ b/internal/cli/repl.go
@@ -284,9 +284,9 @@ func handleBuiltin(input string, ctx *replContext) bool {
 		return true
 	}
 
-	if strings.HasPrefix(lower, "/output-fields") || lower == "/select" || strings.HasPrefix(lower, "/select ") {
+	if lower == "/output-fields" || strings.HasPrefix(lower, "/output-fields ") || lower == "/select" || strings.HasPrefix(lower, "/select ") {
 		var rest string
-		if strings.HasPrefix(lower, "/output-fields") {
+		if lower == "/output-fields" || strings.HasPrefix(lower, "/output-fields ") {
 			rest = strings.TrimSpace(input[len("/output-fields"):])
 		} else {
 			rest = strings.TrimSpace(input[len("/select"):])

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -6,6 +6,8 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/haiyuan-eng-google/dcx-cli/internal/auth"
 	"github.com/haiyuan-eng-google/dcx-cli/internal/contracts"
 	"github.com/haiyuan-eng-google/dcx-cli/internal/output"
@@ -22,6 +24,7 @@ type GlobalOpts struct {
 	CredentialsFile string
 	DryRun          bool
 	OutputFields    string
+	Select          string
 	Retry           int
 }
 
@@ -46,6 +49,18 @@ One binary for BigQuery, Spanner, AlloyDB, Cloud SQL, and Looker.
 Structured output, typed errors, and an MCP bridge for AI agents.`,
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Resolve --select / --output-fields conflict.
+			selectSet := cmd.Flags().Changed("select") || cmd.InheritedFlags().Changed("select")
+			fieldsSet := cmd.Flags().Changed("output-fields") || cmd.InheritedFlags().Changed("output-fields")
+			if selectSet && fieldsSet {
+				return fmt.Errorf("--select and --output-fields cannot be used together")
+			}
+			if selectSet {
+				opts.OutputFields = opts.Select
+			}
+			return nil
+		},
 	}
 
 	// Global flags.
@@ -58,6 +73,7 @@ Structured output, typed errors, and an MCP bridge for AI agents.`,
 	pf.StringVar(&opts.CredentialsFile, "credentials-file", "", "Path to service account JSON credentials file")
 	pf.BoolVar(&opts.DryRun, "dry-run", false, "Validate and show what would be sent without executing")
 	pf.StringVar(&opts.OutputFields, "output-fields", "", "Comma-separated list of fields to include in output (e.g., name,schema)")
+	pf.StringVar(&opts.Select, "select", "", "Alias for --output-fields (cannot be used together)")
 	pf.IntVar(&opts.Retry, "retry", 0, "Number of retries on 429/transport errors (0=no retry, 3=recommended)")
 
 	app := &App{

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -6,10 +6,9 @@
 package cli
 
 import (
-	"fmt"
-
 	"github.com/haiyuan-eng-google/dcx-cli/internal/auth"
 	"github.com/haiyuan-eng-google/dcx-cli/internal/contracts"
+	dcxerrors "github.com/haiyuan-eng-google/dcx-cli/internal/errors"
 	"github.com/haiyuan-eng-google/dcx-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -54,7 +53,10 @@ Structured output, typed errors, and an MCP bridge for AI agents.`,
 			selectSet := cmd.Flags().Changed("select") || cmd.InheritedFlags().Changed("select")
 			fieldsSet := cmd.Flags().Changed("output-fields") || cmd.InheritedFlags().Changed("output-fields")
 			if selectSet && fieldsSet {
-				return fmt.Errorf("--select and --output-fields cannot be used together")
+				dcxerrors.Emit(dcxerrors.InvalidConfig,
+					"--select and --output-fields cannot be used together",
+					"Use one or the other")
+				return nil
 			}
 			if selectSet {
 				opts.OutputFields = opts.Select

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -137,6 +137,7 @@ func GlobalFlags() []FlagContract {
 		{Name: "token", Type: "string", Description: "Bearer access token (overrides all other auth)"},
 		{Name: "credentials-file", Type: "string", Description: "Path to service account JSON credentials file"},
 		{Name: "output-fields", Type: "string", Description: "Comma-separated list of fields to include in output"},
+		{Name: "select", Type: "string", Description: "Alias for --output-fields (cannot be used together)"},
 		{Name: "retry", Type: "int", Description: "Number of retries on 429/transport errors (0=no retry)"},
 	}
 }


### PR DESCRIPTION
## Summary

Adds `--select` as an agent-friendly alias for `--output-fields`. Agents can use the shorter, more intuitive flag for field projection.

## Usage

```bash
# These are equivalent:
dcx datasets list --select=_resource_id,location
dcx datasets list --output-fields=_resource_id,location

# Conflict rejected:
dcx datasets list --select=x --output-fields=y
# → error: --select and --output-fields cannot be used together
```

## Changes

| Area | Change |
|------|--------|
| Root flags | Added `--select` persistent flag |
| PersistentPreRunE | Validates conflict, maps `--select` → `OutputFields` |
| GlobalFlags() | `--select` listed in contract |
| meta describe | Shows `--select` in flag list |
| REPL | `/select` works as alias for `/output-fields` |
| REPL completion | `/select` and `/select clear` in builtins |

## Test plan

- [x] `go build`, `go vet`, `go test ./... -count=1` pass
- [x] `--select=_resource_id` filters output correctly
- [x] `--output-fields` still works unchanged
- [x] `--select` + `--output-fields` together → error
- [x] `meta describe` shows `--select` in flags
- [x] REPL `/select` sets session field filter

Implements #67 Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)