### PR TITLE
Add dcx health / dcx doctor diagnostic command

### DIFF
--- a/internal/cli/health.go
+++ b/internal/cli/health.go
@@ -1,0 +1,327 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/haiyuan-eng-google/dcx-cli/internal/auth"
+	"github.com/haiyuan-eng-google/dcx-cli/internal/contracts"
+	dcxerrors "github.com/haiyuan-eng-google/dcx-cli/internal/errors"
+	"github.com/haiyuan-eng-google/dcx-cli/internal/output"
+	"github.com/haiyuan-eng-google/dcx-cli/internal/profiles"
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
+)
+
+// checkStatus is the status of a single health check.
+type checkStatus string
+
+const (
+	statusOK      checkStatus = "ok"
+	statusWarn    checkStatus = "warn"
+	statusError   checkStatus = "error"
+	statusSkipped checkStatus = "skipped"
+)
+
+// healthCheck is a single check result.
+type healthCheck struct {
+	Name    string      `json:"name"`
+	Status  checkStatus `json:"status"`
+	Detail  string      `json:"detail,omitempty"`
+	Latency string      `json:"latency,omitempty"`
+}
+
+// healthResult is the full health report.
+type healthResult struct {
+	Overall string        `json:"overall"` // "healthy", "degraded", "unhealthy"
+	Checks  []healthCheck `json:"checks"`
+}
+
+func (a *App) addHealthCommand() {
+	cmd := &cobra.Command{
+		Use:     "health",
+		Aliases: []string{"doctor"},
+		Short:   "Run diagnostic checks on auth, project, and API access",
+		Long: `Run a bounded set of diagnostic checks:
+  - Auth source and credential resolution
+  - Token acquisition
+  - Project ID presence
+  - Project access (BigQuery API call)
+  - CA API reachability (if --location set)
+  - Spanner API reachability (if --profile points to Spanner)
+  - Profile validation (if --profile set)
+
+Exit code 0 for healthy/degraded (warnings). Nonzero for auth/project/API failures.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			format, err := a.OutputFormat()
+			if err != nil {
+				dcxerrors.Emit(dcxerrors.InvalidConfig, err.Error(), "Use --format with: "+strings.Join(output.FormatNames(), ", "))
+				return nil
+			}
+
+			profileName, _ := cmd.Flags().GetString("profile")
+			result := runHealthChecks(a, profileName)
+
+			if err := a.Render(format, result); err != nil {
+				return err
+			}
+
+			if result.Overall == "unhealthy" {
+				dcxerrors.Emit(dcxerrors.InfraError, "health check failed", "Run 'dcx health' for details")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().String("profile", "", "Source profile to check connectivity for")
+
+	a.Root.AddCommand(cmd)
+
+	a.Registry.Register(contracts.BuildContract(
+		"health", "cli",
+		"Run diagnostic checks on auth, project, and API access",
+		[]contracts.FlagContract{
+			{Name: "profile", Type: "string", Description: "Source profile to check connectivity for"},
+		}, false, false,
+	))
+}
+
+func runHealthChecks(a *App, profileName string) healthResult {
+	ctx := context.Background()
+	var checks []healthCheck
+	hasError := false
+
+	// 1. Auth source resolution.
+	authCfg := a.AuthConfig()
+	resolved, resolveErr := auth.Resolve(ctx, authCfg)
+	if resolveErr != nil {
+		checks = append(checks, healthCheck{
+			Name:   "auth_source",
+			Status: statusError,
+			Detail: resolveErr.Error(),
+		})
+		hasError = true
+	} else {
+		checks = append(checks, healthCheck{
+			Name:   "auth_source",
+			Status: statusOK,
+			Detail: fmt.Sprintf("method=%s, source=%s", resolved.Method, resolved.Source),
+		})
+	}
+
+	// 2. Token acquisition.
+	if resolved != nil {
+		start := time.Now()
+		_, tokenErr := resolved.TokenSource.Token()
+		latency := time.Since(start).Round(time.Millisecond).String()
+		if tokenErr != nil {
+			checks = append(checks, healthCheck{
+				Name:    "token_acquisition",
+				Status:  statusError,
+				Detail:  tokenErr.Error(),
+				Latency: latency,
+			})
+			hasError = true
+		} else {
+			checks = append(checks, healthCheck{
+				Name:    "token_acquisition",
+				Status:  statusOK,
+				Detail:  "token obtained",
+				Latency: latency,
+			})
+		}
+	} else {
+		checks = append(checks, healthCheck{
+			Name:   "token_acquisition",
+			Status: statusSkipped,
+			Detail: "no auth source",
+		})
+	}
+
+	// 3. Project ID presence.
+	projectID := a.Opts.ProjectID
+	if projectID == "" {
+		checks = append(checks, healthCheck{
+			Name:   "project_id",
+			Status: statusWarn,
+			Detail: "not set (use --project-id or gcloud config)",
+		})
+	} else {
+		checks = append(checks, healthCheck{
+			Name:   "project_id",
+			Status: statusOK,
+			Detail: projectID,
+		})
+	}
+
+	// 4. Project access (lightweight BigQuery datasets.list).
+	if projectID != "" && resolved != nil && !hasError {
+		check := checkBigQueryAccess(ctx, resolved.TokenSource, projectID)
+		checks = append(checks, check)
+		if check.Status == statusError {
+			hasError = true
+		}
+	} else if projectID == "" {
+		checks = append(checks, healthCheck{
+			Name:   "bigquery_access",
+			Status: statusSkipped,
+			Detail: "no project ID",
+		})
+	} else {
+		checks = append(checks, healthCheck{
+			Name:   "bigquery_access",
+			Status: statusSkipped,
+			Detail: "auth failed",
+		})
+	}
+
+	// 5. CA API reachability (if location set).
+	location := a.Opts.Location
+	if location != "" && projectID != "" && resolved != nil && !hasError {
+		check := checkCAAccess(ctx, resolved.TokenSource, projectID, location)
+		checks = append(checks, check)
+	} else {
+		reason := "no --location"
+		if projectID == "" {
+			reason = "no project ID"
+		} else if hasError {
+			reason = "auth failed"
+		}
+		checks = append(checks, healthCheck{
+			Name:   "ca_access",
+			Status: statusSkipped,
+			Detail: reason,
+		})
+	}
+
+	// 6. Profile validation (if --profile set).
+	if profileName != "" {
+		check := checkProfile(profileName)
+		checks = append(checks, check)
+
+		// 7. Spanner access if profile is Spanner.
+		if check.Status == statusOK && resolved != nil && !hasError {
+			p, _ := profiles.LoadByName(profileName)
+			if p != nil && p.SourceType == profiles.Spanner {
+				spannerCheck := checkSpannerAccess(ctx, resolved.TokenSource, p)
+				checks = append(checks, spannerCheck)
+			}
+		}
+	}
+
+	// Determine overall status.
+	overall := "healthy"
+	for _, c := range checks {
+		if c.Status == statusError {
+			overall = "unhealthy"
+			break
+		}
+		if c.Status == statusWarn {
+			overall = "degraded"
+		}
+	}
+
+	return healthResult{
+		Overall: overall,
+		Checks:  checks,
+	}
+}
+
+func checkBigQueryAccess(ctx context.Context, ts oauth2.TokenSource, projectID string) healthCheck {
+	tok, err := ts.Token()
+	if err != nil {
+		return healthCheck{Name: "bigquery_access", Status: statusError, Detail: err.Error()}
+	}
+
+	url := fmt.Sprintf("https://bigquery.googleapis.com/bigquery/v2/projects/%s/datasets?maxResults=1", projectID)
+	req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+
+	start := time.Now()
+	resp, err := http.DefaultClient.Do(req)
+	latency := time.Since(start).Round(time.Millisecond).String()
+
+	if err != nil {
+		return healthCheck{Name: "bigquery_access", Status: statusError, Detail: fmt.Sprintf("network error"), Latency: latency}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 200 {
+		return healthCheck{Name: "bigquery_access", Status: statusOK, Detail: "API reachable", Latency: latency}
+	}
+	if resp.StatusCode == 403 {
+		return healthCheck{Name: "bigquery_access", Status: statusError, Detail: "permission denied", Latency: latency}
+	}
+	return healthCheck{Name: "bigquery_access", Status: statusError, Detail: fmt.Sprintf("HTTP %d", resp.StatusCode), Latency: latency}
+}
+
+func checkCAAccess(ctx context.Context, ts oauth2.TokenSource, projectID, location string) healthCheck {
+	tok, err := ts.Token()
+	if err != nil {
+		return healthCheck{Name: "ca_access", Status: statusError, Detail: err.Error()}
+	}
+
+	url := fmt.Sprintf("https://geminidataanalytics.googleapis.com/v1beta/projects/%s/locations/%s/dataAgents", projectID, location)
+	req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+
+	start := time.Now()
+	resp, err := http.DefaultClient.Do(req)
+	latency := time.Since(start).Round(time.Millisecond).String()
+
+	if err != nil {
+		return healthCheck{Name: "ca_access", Status: statusError, Detail: "network error", Latency: latency}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 200 {
+		return healthCheck{Name: "ca_access", Status: statusOK, Detail: "API reachable", Latency: latency}
+	}
+	if resp.StatusCode == 403 {
+		return healthCheck{Name: "ca_access", Status: statusWarn, Detail: "permission denied (API may not be enabled)", Latency: latency}
+	}
+	if resp.StatusCode == 404 {
+		return healthCheck{Name: "ca_access", Status: statusWarn, Detail: "API not found (may not be enabled for this project)", Latency: latency}
+	}
+	return healthCheck{Name: "ca_access", Status: statusWarn, Detail: fmt.Sprintf("HTTP %d", resp.StatusCode), Latency: latency}
+}
+
+func checkProfile(name string) healthCheck {
+	p, err := profiles.LoadByName(name)
+	if err != nil {
+		return healthCheck{Name: "profile", Status: statusError, Detail: err.Error()}
+	}
+	issues := p.Validate()
+	if len(issues) > 0 {
+		return healthCheck{Name: "profile", Status: statusError, Detail: strings.Join(issues, "; ")}
+	}
+	return healthCheck{Name: "profile", Status: statusOK, Detail: fmt.Sprintf("name=%s, type=%s", p.Name, p.SourceType)}
+}
+
+func checkSpannerAccess(ctx context.Context, ts oauth2.TokenSource, p *profiles.Profile) healthCheck {
+	tok, err := ts.Token()
+	if err != nil {
+		return healthCheck{Name: "spanner_access", Status: statusError, Detail: err.Error()}
+	}
+
+	url := fmt.Sprintf("https://spanner.googleapis.com/v1/projects/%s/instances?pageSize=1", p.Project)
+	req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+
+	start := time.Now()
+	resp, err := http.DefaultClient.Do(req)
+	latency := time.Since(start).Round(time.Millisecond).String()
+
+	if err != nil {
+		return healthCheck{Name: "spanner_access", Status: statusError, Detail: "network error", Latency: latency}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 200 {
+		return healthCheck{Name: "spanner_access", Status: statusOK, Detail: "API reachable", Latency: latency}
+	}
+	return healthCheck{Name: "spanner_access", Status: statusWarn, Detail: fmt.Sprintf("HTTP %d", resp.StatusCode), Latency: latency}
+}

--- a/internal/cli/health.go
+++ b/internal/cli/health.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -69,8 +70,9 @@ Exit code 0 for healthy/degraded (warnings). Nonzero for auth/project/API failur
 				return err
 			}
 
+			// Exit nonzero for unhealthy without emitting a second envelope.
 			if result.Overall == "unhealthy" {
-				dcxerrors.Emit(dcxerrors.InfraError, "health check failed", "Run 'dcx health' for details")
+				os.Exit(2)
 			}
 			return nil
 		},
@@ -81,16 +83,20 @@ Exit code 0 for healthy/degraded (warnings). Nonzero for auth/project/API failur
 	a.Root.AddCommand(cmd)
 
 	a.Registry.Register(contracts.BuildContract(
-		"health", "cli",
-		"Run diagnostic checks on auth, project, and API access",
+		"health", "diagnostics",
+		"Run diagnostic checks on auth, project, and API access (alias: dcx doctor)",
 		[]contracts.FlagContract{
 			{Name: "profile", Type: "string", Description: "Source profile to check connectivity for"},
 		}, false, false,
 	))
 }
 
+// healthTimeout is the maximum time for the entire health check run.
+const healthTimeout = 15 * time.Second
+
 func runHealthChecks(a *App, profileName string) healthResult {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), healthTimeout)
+	defer cancel()
 	var checks []healthCheck
 	hasError := false
 
@@ -245,7 +251,7 @@ func checkBigQueryAccess(ctx context.Context, ts oauth2.TokenSource, projectID s
 	latency := time.Since(start).Round(time.Millisecond).String()
 
 	if err != nil {
-		return healthCheck{Name: "bigquery_access", Status: statusError, Detail: fmt.Sprintf("network error"), Latency: latency}
+		return healthCheck{Name: "bigquery_access", Status: statusError, Detail: sanitizeNetworkError(err), Latency: latency}
 	}
 	defer resp.Body.Close()
 
@@ -273,7 +279,7 @@ func checkCAAccess(ctx context.Context, ts oauth2.TokenSource, projectID, locati
 	latency := time.Since(start).Round(time.Millisecond).String()
 
 	if err != nil {
-		return healthCheck{Name: "ca_access", Status: statusError, Detail: "network error", Latency: latency}
+		return healthCheck{Name: "ca_access", Status: statusError, Detail: sanitizeNetworkError(err), Latency: latency}
 	}
 	defer resp.Body.Close()
 
@@ -316,7 +322,7 @@ func checkSpannerAccess(ctx context.Context, ts oauth2.TokenSource, p *profiles.
 	latency := time.Since(start).Round(time.Millisecond).String()
 
 	if err != nil {
-		return healthCheck{Name: "spanner_access", Status: statusError, Detail: "network error", Latency: latency}
+		return healthCheck{Name: "spanner_access", Status: statusError, Detail: sanitizeNetworkError(err), Latency: latency}
 	}
 	defer resp.Body.Close()
 
@@ -324,4 +330,17 @@ func checkSpannerAccess(ctx context.Context, ts oauth2.TokenSource, p *profiles.
 		return healthCheck{Name: "spanner_access", Status: statusOK, Detail: "API reachable", Latency: latency}
 	}
 	return healthCheck{Name: "spanner_access", Status: statusWarn, Detail: fmt.Sprintf("HTTP %d", resp.StatusCode), Latency: latency}
+}
+
+// sanitizeNetworkError extracts a diagnostic message from a network error
+// without leaking full URLs or tokens.
+func sanitizeNetworkError(err error) string {
+	msg := err.Error()
+	// Extract the useful part: DNS, TLS, timeout, connection refused.
+	for _, keyword := range []string{"no such host", "connection refused", "timeout", "TLS", "certificate", "dial tcp", "context deadline exceeded"} {
+		if strings.Contains(msg, keyword) {
+			return keyword
+		}
+	}
+	return "network error"
 }

--- a/internal/cli/health.go
+++ b/internal/cli/health.go
@@ -132,10 +132,14 @@ func runHealthChecks(a *App, profileName string) healthResult {
 			})
 			hasError = true
 		} else {
+			detail := "token obtained"
+			if resolved.Method == "token" {
+				detail = "static token present (validated on API call)"
+			}
 			checks = append(checks, healthCheck{
 				Name:    "token_acquisition",
 				Status:  statusOK,
-				Detail:  "token obtained",
+				Detail:  detail,
 				Latency: latency,
 			})
 		}
@@ -270,7 +274,7 @@ func checkCAAccess(ctx context.Context, ts oauth2.TokenSource, projectID, locati
 		return healthCheck{Name: "ca_access", Status: statusError, Detail: err.Error()}
 	}
 
-	url := fmt.Sprintf("https://geminidataanalytics.googleapis.com/v1beta/projects/%s/locations/%s/dataAgents", projectID, location)
+	url := fmt.Sprintf("https://geminidataanalytics.googleapis.com/v1beta/projects/%s/locations/%s/dataAgents?pageSize=1", projectID, location)
 	req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
 	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
 

--- a/internal/cli/health_test.go
+++ b/internal/cli/health_test.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSanitizeNetworkError_Keywords(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"dial tcp: lookup api.example.com: no such host", "no such host"},
+		{"dial tcp 127.0.0.1:443: connection refused", "connection refused"},
+		{"context deadline exceeded", "context deadline exceeded"},
+		{"tls: failed to verify certificate", "certificate"},
+		{"Post https://api.example.com: dial tcp: i/o timeout", "timeout"},
+		{"some unknown error", "network error"},
+	}
+	for _, tt := range tests {
+		got := sanitizeNetworkError(errors.New(tt.input))
+		if got != tt.want {
+			t.Errorf("sanitizeNetworkError(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestHealthResult_OverallStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		checks []healthCheck
+		want   string
+	}{
+		{
+			"all ok",
+			[]healthCheck{
+				{Name: "a", Status: statusOK},
+				{Name: "b", Status: statusOK},
+			},
+			"healthy",
+		},
+		{
+			"has warning",
+			[]healthCheck{
+				{Name: "a", Status: statusOK},
+				{Name: "b", Status: statusWarn},
+			},
+			"degraded",
+		},
+		{
+			"has error",
+			[]healthCheck{
+				{Name: "a", Status: statusOK},
+				{Name: "b", Status: statusError},
+			},
+			"unhealthy",
+		},
+		{
+			"error beats warning",
+			[]healthCheck{
+				{Name: "a", Status: statusWarn},
+				{Name: "b", Status: statusError},
+			},
+			"unhealthy",
+		},
+		{
+			"skipped is neutral",
+			[]healthCheck{
+				{Name: "a", Status: statusOK},
+				{Name: "b", Status: statusSkipped},
+			},
+			"healthy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			overall := "healthy"
+			for _, c := range tt.checks {
+				if c.Status == statusError {
+					overall = "unhealthy"
+					break
+				}
+				if c.Status == statusWarn {
+					overall = "degraded"
+				}
+			}
+			if overall != tt.want {
+				t.Errorf("overall = %q, want %q", overall, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckProfile_NotFound(t *testing.T) {
+	check := checkProfile("definitely_nonexistent_profile_xyz")
+	if check.Status != statusError {
+		t.Errorf("expected error for missing profile, got %s", check.Status)
+	}
+}
+
+func TestHealthCheckStatuses(t *testing.T) {
+	// Verify status constants are distinct strings.
+	statuses := []checkStatus{statusOK, statusWarn, statusError, statusSkipped}
+	seen := make(map[checkStatus]bool)
+	for _, s := range statuses {
+		if seen[s] {
+			t.Errorf("duplicate status: %s", s)
+		}
+		seen[s] = true
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -147,6 +147,9 @@ Structured output, typed errors, and an MCP bridge for AI agents.`,
 	// Register MCP commands.
 	app.addMCPCommands()
 
+	// Register health/doctor command.
+	app.addHealthCommand()
+
 	// Register shell completion command.
 	app.addCompletionCommand()
 

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -159,8 +159,8 @@ func TestCommandDiscovery(t *testing.T) {
 		}
 	}
 
-	if len(commands) < 88 {
-		t.Errorf("expected at least 88 commands, got %d", len(commands))
+	if len(commands) < 89 {
+		t.Errorf("expected at least 89 commands, got %d", len(commands))
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `dcx health` (with `dcx doctor` alias) — a bounded diagnostic checklist for auth, project, and API access. No resource scanning or data queries.

## Usage

```bash
# Basic health check
dcx health --project-id=test-project-0728-467323

# With CA check (requires --location)
dcx health --project-id=test-project-0728-467323 --location=us

# With profile validation
dcx health --project-id=test-project-0728-467323 --profile=bench-bq

# Doctor alias
dcx doctor --project-id=test-project-0728-467323

# Compact output
dcx health --compact
```

## Checks

| # | Check | Triggers when | Statuses |
|---|-------|---------------|----------|
| 1 | auth_source | Always | ok / error |
| 2 | token_acquisition | Auth resolved | ok / error / skipped |
| 3 | project_id | Always | ok / warn |
| 4 | bigquery_access | Project + auth OK | ok / error / skipped |
| 5 | ca_access | --location set | ok / warn / skipped |
| 6 | profile | --profile set | ok / error |
| 7 | spanner_access | Profile is Spanner | ok / warn |

## Example output

```json
{
  "overall": "healthy",
  "checks": [
    {"name": "auth_source", "status": "ok", "detail": "method=stored_oauth, source=~/.config/dcx/credentials.json"},
    {"name": "token_acquisition", "status": "ok", "detail": "token obtained", "latency": "109ms"},
    {"name": "project_id", "status": "ok", "detail": "test-project-0728-467323"},
    {"name": "bigquery_access", "status": "ok", "detail": "API reachable", "latency": "628ms"},
    {"name": "ca_access", "status": "skipped", "detail": "no --location"}
  ]
}
```

## Design

- **Bounded**: no resource scans, no table enumeration, no data queries
- **Lightweight API calls**: datasets.list with maxResults=1, instances.list with pageSize=1
- **Exit codes**: 0 for healthy/degraded (warnings), nonzero for auth/project/API failures
- **Typed statuses**: ok, warn, error, skipped
- **Full flag support**: --format, --select, --result-mode, --compact
- **doctor alias**: `dcx doctor` = `dcx health`

## Test plan

- [x] `go build`, `go vet`, `go test ./... -count=1` pass
- [x] 89 commands (was 88)
- [x] `dcx health` returns structured checklist
- [x] `dcx doctor` works as alias
- [x] No --project-id → degraded (warn, not error)
- [x] --profile validates and checks Spanner if applicable
- [x] --compact and --result-mode work
- [x] CA check skipped without --location

Implements #67 Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)