### PR TITLE
Fix CA-aware compaction and MCP index clarity

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -907,7 +907,7 @@ func (s *Server) handleResourcesList(req JSONRPCRequest) {
 	resources = append(resources, MCPResource{
 		URI:         "dcx://index",
 		Name:        "dcx command index",
-		Description: "Summary of all available Data Cloud domains and command counts",
+		Description: "Summary of MCP-available read-only command domains and counts",
 		MimeType:    "application/json",
 	})
 
@@ -1016,6 +1016,7 @@ func (s *Server) readIndexResource(req JSONRPCRequest, uri string) {
 
 	result := map[string]interface{}{
 		"total_commands": total,
+		"scope":          "mcp_read_only",
 		"domains":        summaries,
 	}
 

--- a/internal/output/compact.go
+++ b/internal/output/compact.go
@@ -67,6 +67,11 @@ func CompactResult(data interface{}, mode string) interface{} {
 
 	m, isMap := data.(map[string]interface{})
 
+	// Detect CA AskResult shape before generic fallback.
+	if isMap && isCAResult(m) {
+		return compactCAResult(m, mode)
+	}
+
 	switch mode {
 	case "compact":
 		return compactMode(data, m, isMap)
@@ -260,6 +265,125 @@ func schemaOnlyMode(data interface{}, m map[string]interface{}, isMap bool) inte
 	return map[string]interface{}{
 		"type":   "object",
 		"fields": fields,
+	}
+}
+
+// isCAResult detects a CA AskResult shape: has "results" + at least one of
+// the CA-specific fields (question, source, agent, sql, explanation).
+func isCAResult(m map[string]interface{}) bool {
+	if _, hasResults := m["results"]; !hasResults {
+		return false
+	}
+	caFields := []string{"question", "source", "agent", "sql", "explanation"}
+	for _, f := range caFields {
+		if _, ok := m[f]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// compactCAResult applies domain-aware compaction for CA AskResult responses.
+func compactCAResult(m map[string]interface{}, mode string) interface{} {
+	// Extract nested results.data and results.schema if present.
+	var resultsData []interface{}
+	var resultsSchema []interface{}
+	var resultsName interface{}
+	if resultsRaw, ok := m["results"].(map[string]interface{}); ok {
+		if data, ok := resultsRaw["data"].([]interface{}); ok {
+			resultsData = data
+		}
+		if schema, ok := resultsRaw["schema"].(map[string]interface{}); ok {
+			if fields, ok := schema["fields"].([]interface{}); ok {
+				resultsSchema = fields
+			}
+		}
+		resultsName = resultsRaw["name"]
+	}
+
+	switch mode {
+	case "compact":
+		result := make(map[string]interface{})
+		// Keep high-gravity scalar fields.
+		for _, k := range []string{"question", "source", "agent", "sql"} {
+			if v, ok := m[k]; ok && v != nil {
+				result[k] = v
+			}
+		}
+		// Compact the nested results.data.
+		if resultsData != nil {
+			nested := map[string]interface{}{
+				"count": len(resultsData),
+			}
+			sampleSize := 3
+			if len(resultsData) < sampleSize {
+				sampleSize = len(resultsData)
+			}
+			if sampleSize > 0 {
+				nested["sample"] = resultsData[:sampleSize]
+			}
+			if len(resultsData) > 0 {
+				if first, ok := resultsData[0].(map[string]interface{}); ok {
+					fields := make([]string, 0, len(first))
+					for k := range first {
+						fields = append(fields, k)
+					}
+					sort.Strings(fields)
+					nested["fields"] = fields
+				}
+			}
+			if resultsName != nil {
+				nested["name"] = resultsName
+			}
+			result["results"] = nested
+		}
+		return result
+
+	case "count_only":
+		result := make(map[string]interface{})
+		if resultsData != nil {
+			result["count"] = len(resultsData)
+		} else {
+			result["count"] = 0
+		}
+		if v, ok := m["source"]; ok {
+			result["source"] = v
+		}
+		if v, ok := m["agent"]; ok {
+			result["agent"] = v
+		}
+		return result
+
+	case "schema_only":
+		// Use results.schema.fields if available (the query result schema),
+		// not the AskResult envelope schema.
+		if resultsSchema != nil {
+			result := map[string]interface{}{
+				"item_count": len(resultsData),
+			}
+			var fields []map[string]string
+			for _, f := range resultsSchema {
+				fm, ok := f.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				name, _ := fm["name"].(string)
+				typ, _ := fm["type"].(string)
+				if name != "" {
+					fields = append(fields, map[string]string{
+						"name": name,
+						"type": typ,
+					})
+				}
+			}
+			result["fields"] = fields
+			return result
+		}
+		// Fallback: no nested schema, return envelope fields.
+		return schemaOnlyMode(nil, m, true)
+
+	default:
+		return m
 	}
 }
 

--- a/internal/output/compact.go
+++ b/internal/output/compact.go
@@ -304,8 +304,8 @@ func compactCAResult(m map[string]interface{}, mode string) interface{} {
 	switch mode {
 	case "compact":
 		result := make(map[string]interface{})
-		// Keep high-gravity scalar fields.
-		for _, k := range []string{"question", "source", "agent", "sql"} {
+		// Keep high-gravity scalar fields (including explanation for answer-only responses).
+		for _, k := range []string{"question", "source", "agent", "sql", "explanation"} {
 			if v, ok := m[k]; ok && v != nil {
 				result[k] = v
 			}
@@ -322,7 +322,19 @@ func compactCAResult(m map[string]interface{}, mode string) interface{} {
 			if sampleSize > 0 {
 				nested["sample"] = resultsData[:sampleSize]
 			}
-			if len(resultsData) > 0 {
+			// Prefer schema fields over first-row inference (handles zero-row
+			// results and nullable/missing columns in first row).
+			if resultsSchema != nil {
+				var fields []string
+				for _, f := range resultsSchema {
+					if fm, ok := f.(map[string]interface{}); ok {
+						if name, ok := fm["name"].(string); ok && name != "" {
+							fields = append(fields, name)
+						}
+					}
+				}
+				nested["fields"] = fields
+			} else if len(resultsData) > 0 {
 				if first, ok := resultsData[0].(map[string]interface{}); ok {
 					fields := make([]string, 0, len(first))
 					for k := range first {

--- a/internal/output/compact.go
+++ b/internal/output/compact.go
@@ -268,17 +268,25 @@ func schemaOnlyMode(data interface{}, m map[string]interface{}, isMap bool) inte
 	}
 }
 
-// isCAResult detects a CA AskResult shape: has "results" + at least one of
-// the CA-specific fields (question, source, agent, sql, explanation).
+// isCAResult detects a CA AskResult shape. Matches if the map has "results"
+// plus a CA scalar, OR has "question" plus at least one other CA scalar
+// (handles answer-only responses where results is omitted via omitempty).
 func isCAResult(m map[string]interface{}) bool {
-	if _, hasResults := m["results"]; !hasResults {
-		return false
-	}
 	caFields := []string{"question", "source", "agent", "sql", "explanation"}
+	caCount := 0
 	for _, f := range caFields {
 		if _, ok := m[f]; ok {
-			return true
+			caCount++
 		}
+	}
+	// With "results": need at least 1 CA scalar.
+	if _, hasResults := m["results"]; hasResults && caCount > 0 {
+		return true
+	}
+	// Without "results" (omitempty): need "question" + at least 1 other CA scalar.
+	_, hasQuestion := m["question"]
+	if hasQuestion && caCount >= 2 {
+		return true
 	}
 	return false
 }

--- a/internal/output/compact_test.go
+++ b/internal/output/compact_test.go
@@ -172,6 +172,15 @@ func TestCompactCAResult_Compact(t *testing.T) {
 	if nested["name"] != "top_events" {
 		t.Errorf("results.name not preserved: %v", nested["name"])
 	}
+	// Fields should come from schema, not first-row inference.
+	fields, ok := nested["fields"].([]string)
+	if !ok {
+		t.Fatalf("fields should be []string, got %T", nested["fields"])
+	}
+	// Schema order: event_type, count (not sorted alphabetically).
+	if len(fields) != 2 || fields[0] != "event_type" || fields[1] != "count" {
+		t.Errorf("fields should come from schema order: %v", fields)
+	}
 }
 
 func TestCompactCAResult_CountOnly(t *testing.T) {
@@ -270,6 +279,9 @@ func TestCompactCAResult_AnswerOnly(t *testing.T) {
 	}
 	if m["source"] != "BigQuery" {
 		t.Errorf("source not preserved")
+	}
+	if m["explanation"] != "This is a dataset about..." {
+		t.Errorf("explanation not preserved: %v", m["explanation"])
 	}
 	// Should not return keys-only generic output.
 	if _, hasKeys := m["keys"]; hasKeys {

--- a/internal/output/compact_test.go
+++ b/internal/output/compact_test.go
@@ -289,16 +289,51 @@ func TestCompactCAResult_AnswerOnly(t *testing.T) {
 	}
 }
 
+func TestCompactCAResult_NoResultsKey(t *testing.T) {
+	// Regression: AskResult.Results is omitempty. When CA returns only
+	// a natural-language answer, results is omitted after JSON round-trip.
+	data := map[string]interface{}{
+		"question":    "explain this dataset",
+		"source":      "BigQuery",
+		"explanation": "This dataset contains agent event logs...",
+		"agent":       "my-agent",
+	}
+
+	result := CompactResult(data, "compact")
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("compact should return a map, got %T", result)
+	}
+	if m["question"] != "explain this dataset" {
+		t.Errorf("question not preserved: %v", m["question"])
+	}
+	if m["explanation"] != "This dataset contains agent event logs..." {
+		t.Errorf("explanation not preserved: %v", m["explanation"])
+	}
+	if m["source"] != "BigQuery" {
+		t.Errorf("source not preserved")
+	}
+	if _, hasKeys := m["keys"]; hasKeys {
+		t.Error("should not fall through to generic keys-only compaction")
+	}
+	if _, hasType := m["type"]; hasType {
+		t.Error("should not return generic object type")
+	}
+}
+
 func TestIsCAResult(t *testing.T) {
 	tests := []struct {
 		name string
 		m    map[string]interface{}
 		want bool
 	}{
-		{"CA result", map[string]interface{}{"results": map[string]interface{}{}, "question": "x"}, true},
+		{"CA result with results", map[string]interface{}{"results": map[string]interface{}{}, "question": "x"}, true},
 		{"CA result with source", map[string]interface{}{"results": map[string]interface{}{}, "source": "BQ"}, true},
 		{"list envelope", map[string]interface{}{"items": []interface{}{}, "source": "BQ"}, false},
-		{"no results key", map[string]interface{}{"question": "x", "sql": "y"}, false},
+		{"answer-only no results (question+explanation)", map[string]interface{}{"question": "x", "explanation": "y"}, true},
+		{"answer-only no results (question+source)", map[string]interface{}{"question": "x", "source": "BQ"}, true},
+		{"question only (no second CA field)", map[string]interface{}{"question": "x"}, false},
+		{"no question no results", map[string]interface{}{"sql": "y", "source": "BQ"}, false},
 		{"results but no CA fields", map[string]interface{}{"results": map[string]interface{}{}, "foo": "bar"}, false},
 	}
 	for _, tt := range tests {

--- a/internal/output/compact_test.go
+++ b/internal/output/compact_test.go
@@ -123,6 +123,181 @@ func TestResultModeNames(t *testing.T) {
 	}
 }
 
+// CA-aware compaction tests.
+
+func TestCompactCAResult_Compact(t *testing.T) {
+	data := map[string]interface{}{
+		"question":    "top events",
+		"source":      "BigQuery",
+		"agent":       "my-agent",
+		"sql":         "SELECT event_type, COUNT(*) ...",
+		"explanation": "The top events are...",
+		"results": map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{"event_type": "LLM_RESPONSE", "count": float64(54)},
+				map[string]interface{}{"event_type": "LLM_REQUEST", "count": float64(52)},
+				map[string]interface{}{"event_type": "AGENT_COMPLETED", "count": float64(35)},
+			},
+			"schema": map[string]interface{}{
+				"fields": []interface{}{
+					map[string]interface{}{"name": "event_type", "type": "STRING"},
+					map[string]interface{}{"name": "count", "type": "INTEGER"},
+				},
+			},
+			"name": "top_events",
+		},
+	}
+
+	result := CompactResult(data, "compact")
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		t.Fatalf("compact CA result should be a map, got %T", result)
+	}
+	if m["question"] != "top events" {
+		t.Errorf("question not preserved: %v", m["question"])
+	}
+	if m["source"] != "BigQuery" {
+		t.Errorf("source not preserved: %v", m["source"])
+	}
+	if m["sql"] == nil {
+		t.Error("sql should be preserved")
+	}
+	nested, ok := m["results"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("results should be a map, got %T", m["results"])
+	}
+	if nested["count"] != 3 {
+		t.Errorf("results.count = %v, want 3", nested["count"])
+	}
+	if nested["name"] != "top_events" {
+		t.Errorf("results.name not preserved: %v", nested["name"])
+	}
+}
+
+func TestCompactCAResult_CountOnly(t *testing.T) {
+	data := map[string]interface{}{
+		"question": "how many?",
+		"source":   "BigQuery",
+		"agent":    "my-agent",
+		"results": map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{"total": float64(318)},
+			},
+		},
+	}
+
+	result := CompactResult(data, "count_only")
+	m := result.(map[string]interface{})
+	if m["count"] != 1 {
+		t.Errorf("count = %v, want 1", m["count"])
+	}
+	if m["source"] != "BigQuery" {
+		t.Errorf("source not preserved")
+	}
+	if m["agent"] != "my-agent" {
+		t.Errorf("agent not preserved")
+	}
+}
+
+func TestCompactCAResult_SchemaOnly(t *testing.T) {
+	data := map[string]interface{}{
+		"question": "top events",
+		"source":   "BigQuery",
+		"results": map[string]interface{}{
+			"data": []interface{}{
+				map[string]interface{}{"event_type": "X", "count": float64(1)},
+				map[string]interface{}{"event_type": "Y", "count": float64(2)},
+			},
+			"schema": map[string]interface{}{
+				"fields": []interface{}{
+					map[string]interface{}{"name": "event_type", "type": "STRING"},
+					map[string]interface{}{"name": "count", "type": "INTEGER"},
+				},
+			},
+		},
+	}
+
+	result := CompactResult(data, "schema_only")
+	m := result.(map[string]interface{})
+	fields, ok := m["fields"].([]map[string]string)
+	if !ok {
+		t.Fatalf("fields should be []map[string]string, got %T", m["fields"])
+	}
+	if len(fields) != 2 {
+		t.Errorf("expected 2 fields, got %d", len(fields))
+	}
+	// Should use schema field types (STRING, INTEGER), not JSON type inference.
+	if fields[0]["type"] != "STRING" {
+		t.Errorf("field type should be STRING from schema, got %q", fields[0]["type"])
+	}
+}
+
+func TestCompactCAResult_ZeroRows(t *testing.T) {
+	data := map[string]interface{}{
+		"question": "empty",
+		"source":   "BigQuery",
+		"results": map[string]interface{}{
+			"data": []interface{}{},
+			"schema": map[string]interface{}{
+				"fields": []interface{}{
+					map[string]interface{}{"name": "x", "type": "STRING"},
+				},
+			},
+		},
+	}
+
+	result := CompactResult(data, "compact")
+	m := result.(map[string]interface{})
+	nested := m["results"].(map[string]interface{})
+	if nested["count"] != 0 {
+		t.Errorf("zero-row count = %v, want 0", nested["count"])
+	}
+}
+
+func TestCompactCAResult_AnswerOnly(t *testing.T) {
+	// CA response with explanation but no tabular results.
+	data := map[string]interface{}{
+		"question":    "what is this?",
+		"source":      "BigQuery",
+		"explanation": "This is a dataset about...",
+		"results":     map[string]interface{}{},
+	}
+
+	result := CompactResult(data, "compact")
+	m := result.(map[string]interface{})
+	if m["question"] != "what is this?" {
+		t.Errorf("question not preserved: %v", m["question"])
+	}
+	if m["source"] != "BigQuery" {
+		t.Errorf("source not preserved")
+	}
+	// Should not return keys-only generic output.
+	if _, hasKeys := m["keys"]; hasKeys {
+		t.Error("should not fall through to generic keys-only compaction")
+	}
+}
+
+func TestIsCAResult(t *testing.T) {
+	tests := []struct {
+		name string
+		m    map[string]interface{}
+		want bool
+	}{
+		{"CA result", map[string]interface{}{"results": map[string]interface{}{}, "question": "x"}, true},
+		{"CA result with source", map[string]interface{}{"results": map[string]interface{}{}, "source": "BQ"}, true},
+		{"list envelope", map[string]interface{}{"items": []interface{}{}, "source": "BQ"}, false},
+		{"no results key", map[string]interface{}{"question": "x", "sql": "y"}, false},
+		{"results but no CA fields", map[string]interface{}{"results": map[string]interface{}{}, "foo": "bar"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCAResult(tt.m); got != tt.want {
+				t.Errorf("isCAResult = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestJSONTypeOf(t *testing.T) {
 	tests := []struct {
 		input interface{}


### PR DESCRIPTION
## Summary

Fixes findings 1-3 from issue #71 (E2E test findings).

### Before/After

**`ca ask --compact` (Finding 1):**
```
Before: {"keys":["agent","explanation","question","results","source","sql"],"type":"object"}
After:  {"question":"top 3 events?","source":"BigQuery","sql":"SELECT...","results":{"count":3,"sample":[...],"fields":["event_count","event_type"]}}
```

**`ca ask --result-mode=schema_only` (Finding 2):**
```
Before: {"fields":[{"name":"agent","type":"string"},{"name":"explanation","type":"string"},...]}
After:  {"fields":[{"name":"event_type","type":"STRING"},{"name":"event_count","type":"INTEGER"}],"item_count":3}
```

**MCP resource index (Finding 3):**
```
Before: {"total_commands":57,"domains":[...]}
After:  {"total_commands":57,"scope":"mcp_read_only","domains":[...]}
```

### How it works

`CompactResult` now detects the CA AskResult shape (has `results` + at least one of `question`/`source`/`agent`/`sql`/`explanation`) before falling through to generic object compaction:

- **compact**: keeps question, source, agent, sql; compacts results.data with count/sample/fields
- **count_only**: row count + source + agent
- **schema_only**: uses `results.schema.fields` types (STRING, INTEGER) not JSON type inference
- **answer-only** (no tabular data): preserves question, source, explanation

### Tests

7 CA compaction tests + 5 isCAResult detection cases.

## Test plan

- [x] `go build`, `go vet`, `go test ./... -count=1` pass
- [x] `ca ask --compact` returns question + sql + compacted results (real API)
- [x] `ca ask --result-mode=schema_only` returns query schema fields (real API)
- [x] `ca ask --result-mode=count_only` returns count + source + agent (real API)
- [x] MCP index includes `scope: "mcp_read_only"`

Fixes #71 (findings 1-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)